### PR TITLE
Reference fixes

### DIFF
--- a/hep-eppsu-software.bib
+++ b/hep-eppsu-software.bib
@@ -1,3 +1,22 @@
+@article{10.1145/2934664,
+author = {Zaharia, Matei and Xin, Reynold S. and Wendell, Patrick and Das, Tathagata and Armbrust, Michael and Dave, Ankur and Meng, Xiangrui and Rosen, Josh and Venkataraman, Shivaram and Franklin, Michael J. and Ghodsi, Ali and Gonzalez, Joseph and Shenker, Scott and Stoica, Ion},
+title = {Apache Spark: a unified engine for big data processing},
+year = {2016},
+issue_date = {November 2016},
+publisher = {Association for Computing Machinery},
+address = {New York, NY, USA},
+volume = {59},
+number = {11},
+issn = {0001-0782},
+url = {https://doi.org/10.1145/2934664},
+doi = {10.1145/2934664},
+abstract = {This open source computing framework unifies streaming, batch, and interactive big data workloads to unlock new applications.},
+journal = {Commun. ACM},
+month = oct,
+pages = {56–65},
+numpages = {10}
+}
+
 @article{10.21468/SciPostPhys.16.5.130,
   title     = {{Event generators for high-energy physics experiments}},
   author    = {J. M. Campbell and M. Diefenthaler and T. J. Hobbs and S. Höche
@@ -56,6 +75,30 @@
   url       = {https://scipost.org/10.21468/SciPostPhys.16.5.130}
 }
 
+@ARTICLE{1610988,
+  author={Allison, J. and Amako, K. and Apostolakis, J. and Araujo, H. and Arce Dubois, P. and Asai, M. and Barrand, G. and Capra, R. and Chauvie, S. and Chytracek, R. and Cirrone, G.A.P. and Cooperman, G. and Cosmo, G. and Cuttone, G. and Daquino, G.G. and Donszelmann, M. and Dressel, M. and Folger, G. and Foppiano, F. and Generowicz, J. and Grichine, V. and Guatelli, S. and Gumplinger, P. and Heikkinen, A. and Hrivnacova, I. and Howard, A. and Incerti, S. and Ivanchenko, V. and Johnson, T. and Jones, F. and Koi, T. and Kokoulin, R. and Kossov, M. and Kurashige, H. and Lara, V. and Larsson, S. and Lei, F. and Link, O. and Longo, F. and Maire, M. and Mantero, A. and Mascialino, B. and McLaren, I. and Mendez Lorenzo, P. and Minamimoto, K. and Murakami, K. and Nieminen, P. and Pandola, L. and Parlati, S. and Peralta, L. and Perl, J. and Pfeiffer, A. and Pia, M.G. and Ribon, A. and Rodrigues, P. and Russo, G. and Sadilov, S. and Santin, G. and Sasaki, T. and Smith, D. and Starkov, N. and Tanaka, S. and Tcherniaev, E. and Tome, B. and Trindade, A. and Truscott, P. and Urban, L. and Verderi, M. and Walkden, A. and Wellisch, J.P. and Williams, D.C. and Wright, D. and Yoshida, H.},
+  journal={IEEE Transactions on Nuclear Science}, 
+  title={Geant4 developments and applications}, 
+  year={2006},
+  volume={53},
+  number={1},
+  pages={270-278},
+  keywords={Object oriented modeling;Physics;Production;Kernel;Application software;Large Hadron Collider;Software tools;Medical simulation;Astrophysics;Protection;Electromagnetic interactions;hadronic interactions;object-oriented technology;particle interactions;physics validation;simulation},
+  doi={10.1109/TNS.2006.869826}
+}
+
+@article{Aaij2020Allen,
+author = {Aaij, R.  and  Albrecht, J.  and  Belous, M.  and  Billoir, P.  and  Boettcher, T.  and  Brea Rodríguez, A.  and  vom Bruch, D.  and  Cámpora Pérez, D. H.  and  Casais Vidal, A.  and  Craik, D. C.  and  Fernandez Declara, P.  and  Funke, L.  and  Gligorov, V. V.  and  Jashal, B.  and  Kazeev, N.  and  Martínez Santos, D.  and  Pisani, F.  and  Pliushchenko, D.  and  Popov, S.  and  Quagliani, R.  and  Rangel, M.  and  Reiss, F.  and  Sánchez Mayordomo, C.  and  Schwemmer, R.  and  Sokoloff, M.  and  Stevens, H.  and  Ustyuzhanin, A.  and  Vilasís Cardona, X.  and  Williams, M.},
+title = {Allen: A High-Level Trigger on GPUs for LHCb},
+journal = {Computing and Software for Big Science},
+year  = {2020},
+volume  = {4},
+issue = {1},
+pages = {7-},
+doi  = {10.1007/s41781-020-00039-7},
+url  = {https://doi.org/10.1007/s41781-020-00039-7}
+}
+
 @article{Aamir_2024,
   title     = {Using graph neural networks to reconstruct charged pion showers
                in the CMS High Granularity Calorimeter},
@@ -86,6 +129,47 @@
   primaryclass  = {hep-ex}
 }
 
+@article{Ai2022Common,
+author = {Ai, Xiaocong  and  Allaire, Corentin  and  Calace, Noemi  and  Czirkos, Angéla  and  Elsing, Markus  and  Ene, Irina  and  Farkas, Ralf  and  Gagnon, Louis-Guillaume  and  Garg, Rocky  and  Gessinger, Paul  and  Grasland, Hadrien  and  Gray, Heather M.  and  Gumpert, Christian  and  Hrdinka, Julia  and  Huth, Benjamin  and  Kiehn, Moritz  and  Klimpel, Fabian  and  Kolbinger, Bernadette  and  Krasznahorkay, Attila  and  Langenberg, Robert  and  Leggett, Charles  and  Mania, Georgiana  and  Moyse, Edward  and  Niermann, Joana  and  Osborn, Joseph D.  and  Rousseau, David  and  Salzburger, Andreas  and  Schlag, Bastian  and  Tompkins, Lauren  and  Yamazaki, Tomohiro  and  Yeo, Beomki  and  Zhang, Jin},
+title = {A Common Tracking Software Project},
+journal = {Computing and Software for Big Science},
+year  = {2022},
+volume  = {6},
+issue = {1},
+pages = {8-},
+doi  = {10.1007/s41781-021-00078-8},
+url  = {https://doi.org/10.1007/s41781-021-00078-8}
+}
+
+@article{ALICE:LS2_upgrades,
+doi = {10.1088/1748-0221/19/05/P05062},
+url = {https://dx.doi.org/10.1088/1748-0221/19/05/P05062},
+year = {2024},
+month = may,
+publisher = {IOP Publishing},
+volume = {19},
+number = {05},
+pages = {P05062},
+author = {Acharya, S. and Acosta Hernandez, R. and Adamová, D. and Adler, A. and Adolfsson, J. and Agguiaro, D. and Aglieri Rinella, G. and Agnello, M. and Agnese, F. and Agrawal, N. and Aguilar Salazar, S. and Ahammed, Z. and Ahmad, S. and Ahmed, M.U. and Ahn, S.U. and Ahuja, I. and Aiola, S. and Akindinov, A. and Al-Turany, M. and Alarcon Cubas, H.G. and Aleksandrov, D. and Alessandro, B. and Alexis, M. and Alexopoulos, K. and Alfanda, H.M. and Alfaro Molina, R. and Alfarone, G. and Ali, B. and Alici, A. and Alizadehvandchali, N. and Alkin, A. and Alme, J. and Alocco, G. and Alt, T. and Altsybeev, I. and Amend, W. and Anaam, M.N. and Anastasopoulos, F. and Anderssen, E.C. and Andrei, C. and Andreou, D. and Andronic, A. and Angelsmark, M.T. and Anguelov, V. and Anjam, A. and Antinori, F. and Antonioli, P. and Apadula, N. and Aphecetche, L. and Appelshäuser, H. and Aprodu, V. and Arata, C. and Arba, M. and Arcelli, S. and Aresti, M. and Arnaldi, R. and Arneiro, J.G.M.C.A. and Arnold, O.W. and Arsene, I.C. and Arslandok, M. and Atkinson, P. and Augustinus, A. and Averbeck, R. and Ayala Pabon, A. and Azmi, M.D. and Azzan, C. and Baccomi, R. and Badalà, A. and Bae, J. and Baek, Y.W. and Bai, X. and Bailhache, R. and Bailung, Y. and Baitinger, D. and Balbino, A. and Baldanza, C. and Baldisseri, A. and Balis, B. and Ball, M. and Banerjee, D. and Banoo, Z. and Barbera, R. and Barberis, P. and Barile, F. and Barioglio, L. and Barlou, M. and Barnaföldi, G.G. and Barnby, L.S. and Barret, V. and Barreto, L. and Bartels, C. and Barth, K. and Barthel, R.G.E. and Bartsch, E. and Baruffaldi, F. and Bastid, N. and Basu, S. and Batigne, G. and Battistini, D. and Batyunya, B. and Bauri, D. and Bazo Alba, J.L. and Bearden, I.G. and Beattie, C. and Becht, P. and Behera, D. and Belikov, I. and Bell Hechavarria, A.D.C. and Bellini, F. and Bellwied, R. and Belokurova, S. and Belyaev, V. and Benato, A. and Bencedi, G. and Benettoni, M. and Beney, J.L. and Benotto, F. and Beole, S. and Berdnikov, Y. and Berdnikova, A. and Berger, M.E. and Bergmann, L. and Berzano, D. and Besoiu, M.G. and Betev, L. and Bez, N. and Bhaduri, P.P. and Bhasin, A. and Bhat, M.A. and Bhattacharjee, B. and Bhatti, A.S. and Bhopal, M.F. and Bialas, N. and Białas, P. and Bianchi, L. and Bianchi, N. and Bielčík, J. and Bielčíková, J. and Biernat, J. and Bigot, A.P. and Bilandzic, A. and Biro, G. and Biswas, S. and Bize, N. and Blair, J.T. and Blau, D. and Blidaru, M.B. and Bluhme, N. and Blume, C. and Boca, G. and Bock, F. and Bodova, T. and Bogdanov, A. and Boi, S. and Bok, J. and Boldizsár, L. and Bombara, M. and Bond, P.M. and Bonnevaux, A. and Bonomi, G. and Bonora, M. and Borel, H. and Borissov, A. and Borotto Dalla Vecchia, F. and Borquez Carcamo, A.G. and Borri, M. and Borshchov, V. and Bossi, H. and Botta, E. and Bouvier, S. and Bouziani, Y.E.M. and Boynton, L. and Bratrud, L. and Braun-Munzinger, P. and Bregant, M. and Britton, C. and Brouwer, G. and Broz, M. and Brücken, E.J. and Brucker, S. and Brulin, G. and Bruna, E. and Brunasso Cattarello, O. and Bruno, G.E. and Buckland, M.D. and Budnikov, D. and Buesching, H. and Bufalino, S. and Bugnon, O. and Buhler, P. and Buhour, J.-M. and Buncic, P. and Burmasov, N. and Buthelezi, Z. and Bysiak, S.A. and Cabanillas Noris, J.C. and Cai, M. and Caines, H. and Caliva, A. and Calvo Villar, E. and Camacho, J.M.M. and Camerini, P. and Canedo, F.D.M. and Carabas, M. and Caragheorgheopol, G. and Carballo, A.A. and Carena, W. and Cariola, P. and Carnesecchi, F. and Caron, R. and Carvalho, L.A.D. and Castelneau, G. and Castillo Castellanos, J. and Castro, A.J. and Catalano, F. and Cavalcante De Souza Sanches, B. and Cavazza, D. and Ceballos Sanchez, C. and Chakaberia, I. and Chakraborty, P. and Chandra, S. and Chapeland, S. and Chartier, M. and Chattopadhyay, S. and Chattopadhyay, S. and Chatzidaki, P. and Chavez, T.G. and Cheng, T. and Cheshkov, C. and Cheynis, B. and Chibante Barroso, V. and Chinellato, D.D. and Chizzali, E.S. and Cho, J. and Cho, S. and Chochula, P. and Christakoglou, P. and Christensen, C.H. and Christensen, S.G. and Christiansen, P. and Chujo, T. and Ciacco, M. and Cicalo, C. and Cindolo, F. and Ciupek, M.R. and Clague, N.J. and Clai, G. and Clausse, O.A. and Clonts, L.G. and Colamaria, F. and Colburn, J.S. and Colella, D. and Coli, S. and Collu, A. and Colocci, M. and Concas, M. and Conesa Balbastre, G. and Conesa del Valle, Z. and Contin, G. and Contreras, J.G. and Coquet, M.L. and Cormier, T.M. and Corrales Morales, Y. and Cortese, P. and Cosentino, M.R. and Costa, F. and Costanza, S. and Cot, C. and Cotto, G. and Crkovská, J. and Crochet, P. and Crowley, J.R. and Cruz-Torres, R. and Cuautle, E. and Cui, P. and Da Silva, R.W. and Dainese, A. and Dainton, J.B. and Danè, E. and Danisch, M.C. and Danu, A. and Das, A. and Das, D. and Das, D. and Das, P. and Das, P. and Das, S. and Dash, A.R. and Dash, S. and David, R.M.H. and De Caro, A. and De Carvalho, D. and de Cataldo, G. and De Cilladi, L. and de Cuveland, J. and De Falco, A. and De Gruttola, D. and De Marco, N. and De Martin, C. and De Pasquale, S. and De Remigis, P. and De Robertis, G. and Deb, R. and Deb, S. and Debski, R.J. and Degraw, W. and Deisting, A. and Deja, K.R. and Del Grande, R. and Dellacasa, G. and Della Negra, R.M. and Dello Stritto, L. and Deng, W. and Dhankher, P. and Di Bari, D. and Di Mauro, A. and Diaz, R.A. and Dietel, T. and Ding, Y. and Dittrich, S. and Divià, R. and Dixit, D.U. and Djuvsland, Ø. and Dmitrieva, U. and Do Couto, A.L. and Dobrin, A. and Domingues Goncalves, C.M. and Dönigus, B. and Dubinski, J.M. and Dubla, A. and Dudi, S. and Dumitrache, F. and Dupieux, P. and Durkac, M. and Duta, V. and Dzalaiova, N. and Eder, T.M. and Ehlers, R.J. and Eikeland, V.N. and Eisenhut, F. and Elia, D. and Engel, M.J. and Eppler, J.B. and Erazmus, B. and Ercolessi, F. and Erhardt, F. and Ericson, M.N. and Ersdal, M.R. and Espagnon, B. and Eulisse, G. and Evans, D. and Evdokimov, S. and Ezell, N.D.B. and Fabbietti, L. and Faggin, M. and Faivre, J. and Falchieri, D. and Fan, F. and Fan, W. and Fantoni, A. and Fasel, M. and Fecchio, P. and Feliciello, A. and Feofilov, G. and Ferencei, J. and Fernández Téllez, A. and Ferrandi, L. and Ferrer, M.B. and Ferrero, A. and Ferrero, C. and Ferretti, A. and Festanti, A. and Feuillard, V.J.G. and Fichera, F. and Filova, V. and Finogeev, D. and Fionda, F.M. and Fiorenza, G. and Flatland, E. and Flor, F. and Flores, A.N. and Flouzat, C. and Foertsch, S. and F"ohner, G. and Fokin, I. and Fokin, S. and Fragiacomo, E. and Frajna, E. and Franco, A. and Frankenfeld, U. and Fransen, J.P. and Fuchs, U. and Funicello, N. and Furget, C. and Furs, A. and Fusayasu, T. and Futo, E. and Gaardhøje, J.J. and Gagliardi, M. and Gago, A.M. and Gajanana, D. and Gal, A. and Galdames Perez, A. and Gallian, S. and Galvan, C.D. and Gangadharan, D.R. and Ganoti, P. and Gao, C. and Garabatos, C. and Garcia, J.R.A. and Garcia-Solis, E. and Garg, K. and Gargiulo, C. and Garizzo, L. and Garner, K. and Gasik, P. and Gautam, A. and Gay Ducati, M.B. and Geiger, T. and Gera, A.L. and Germain, M. and Gheata, M. and Ghimouz, A. and Ghosh, C. and Giacalone, M. and Giubellino, P. and Giubilato, P. and Glaenzer, A.M.C. and Glässel, P. and Glimos, E. and Goffe, M. and Goh, D.J.Q. and Gonzalez, V. and Gorgon, M. and Gotovac, S. and Grabas, A.M. and Grabski, V. and Grachov, O.A. and Graczykowski, L.K. and Grant, A.F. and Grecka, E. and Grein, A. and Greiner, L. and Grelli, A. and Grigoras, C. and Grigoriev, V. and Grigoryan, S. and Grimaldi, A. and Grosa, F. and Grosse-Oetringhaus, J.F. and Grosso, R. and Grund, D. and Guard, A.E. and Guardiano, G.G. and Guernane, R. and Guilbaud, M. and Guillamet, M.J. and Guilloux, F. and Gul, M. and Gulbrandsen, K. and Gündem, T. and Gunji, T. and Guo, W. and Guo Hu, C. and Gupta, A. and Gupta, R. and Gupta, R. and Guzman, S.P. and Guzzo Neves, H. and Gyulai, L. and Habib, M.K. and Hadjidakis, C. and Haider, F.U. and Hamagaki, H. and Hamdi, A. and Hamid, M. and Han, Y. and Hannigan, R. and Hansen, J.C. and Haque, M.R. and Hardi, N. and Harlenderova, A. and Harris, J.W. and Harton, A. and Hassan, H. and Hassan, S. and Hatzifotiadou, D. and Hauer, P. and Havener, L.B. and Heckel, S.T. and Hehner, J.L. and Heino, J. and Hellbär, E. and Helstrup, H. and Hemmer, M. and Herghelegiu, A. and Herman, T. and Hernandes da Costa Porto, L. and Hernandez Herrera, H.D. and Herold, T. and Herrera Corral, G. and Herrmann, F. and Herrmann, S. and Hetland, K.F. and Heybeck, B. and Hilden, T.E. and Hill, A. and Hillemanns, H. and Hills, C. and Hindley, P. and Hippolyte, B. and Hoffmann, F.W. and Hofman, B. and Hohlweger, B. and Hong, G.H. and Hornung, S. and Horst, M. and Horzyk, A. and Hou, Y. and Hristov, P. and Hřivnáčová, I. and Huang, G. and Hughes, C. and Huhn, P. and Huhta, L.M. and Hulse, C.V. and Humanic, T.J. and Hummel, S. and Hutson, A. and Hutter, D. and Iddon, J.P. and Igolkin, S. and Ijzermans, P. and Ilkaev, R. and Ilyas, H. and Imhoff, M.A. and Imre, M. and Inaba, M. and Innocenti, G.M. and Ippolitov, M. and Isakov, A. and Isidori, T. and Islam, M.S. and Ivanishchev, D. and Ivanov, M. and Ivanov, M. and Ivanov, V. and Jablonski, M. and Jacak, B. and Jacazio, N. and Jacobs, P.M. and Jadlovska, S. and Jadlovsky, J. and Jaelani, S. and Jaffe, L. and Jager, J.N. and Jahnke, C. and Jakubowska, M.J. and Janik, M.A. and Janson, T. and Jercic, M. and Jia, S. and Jimenez, A.A.P. and Johnson, T. and Joly, B. and Jonas, F. and Jouve, F. and Jowett, J.M. and Jung, J. and Jung, M. and Junique, A. and Jusko, A. and Just, D. and Kabus, M.J. and Kaewjai, J. and Kalinak, P. and Kalteyer, A.S. and Kalweit, A. and Kangasaho, E. and Kaplin, V. and Karasu Uysal, A. and Karatovic, D. and Karavichev, O. and Karavicheva, T. and Karayan, L. and Karczmarczyk, P. and Karpechev, E. and Kebschull, U. and Keidel, R. and Keijdener, D.L.D. and Keil, M. and Ketzer, B. and Khabanova, Z. and Khade, S.S. and Khan, A.M. and Khan, H. and Khan, S. and Khanzadeev, A. and Kharlov, Y. and Khatun, A. and Khuntia, A. and Kidson, M.B. and Kileng, B. and Kim, B. and Kim, C. and Kim, D.J. and Kim, E.J. and Kim, J. and Kim, J.S. and Kim, J. and Kim, M. and Kim, S. and Kim, T. and Kimura, K. and Kirsch, S. and Kisel, I. and Kiselev, S. and Kisiel, A. and Kitowski, J.P. and Klay, J.L. and Klein, J. and Klein, S. and Klein-Bösing, C. and Kleiner, M. and Klemenz, T. and Klewin, S. and Kluge, A. and Knospe, A.G. and Kobdaj, C. and Kollegger, T. and Kondratyev, A. and Kondratyeva, N. and Kondratyuk, E. and Konig, J. and Konigstorfer, S.A. and Konopka, P.J. and Kornakov, G. and Korwieser, M. and Koryciak, S.D. and Koskinen, E. and Kotliarov, A. and Kovalenko, V. and Kowalski, M. and Kozhuharov, V. and Kraan, M.J. and Králik, I. and Kravčáková, A. and Krcal, L. and Kreis, L. and Krivda, M. and Krizek, F. and Krizkova Gajdosova, K. and Kroesen, M. and Krüger, M. and Krupova, D.M. and Kryshen, E. and Kučera, V. and Kugathasan, T. and Kuhn, C. and Kuijer, P.G. and Kumaoka, T. and Kumar, D. and Kumar, L. and Kumar, N. and Kumar, S. and Kundu, S. and Kurashvili, P. and Kurepin, A. and Kurepin, A.B. and Kuriakose, R.K. and Kuryakin, A. and Kushpil, S. and Kvapil, J. and Kweon, M.J. and Kwon, J.Y. and Kwon, Y. and Ky, B.Y. and La Pointe, S.L. and La Rocca, P. and Lacalamita, N. and Lafarguette, P. and Lai, Y.S. and Lakrathok, A. and Lamanna, M. and Lang, R. and Langoy, R. and Larionov, P. and Laudi, E. and Lautner, L. and Lavicka, R. and Lazareva, T. and Le Galliard, C. and Lea, R. and Lebedev, A. and Ledey, G. and Lee, H. and Lee, T. and Legras, G. and Lehrbach, J. and Lelek, T.M. and Lemmon, R.C. and León Monzón, I. and Lesch, M.M. and Lesenechal, Y. and Lesser, E.D. and Lettrich, M. and Lévai, P. and Li, X. and Li, X.L. and Librizzi, F. and Liebske, F. and Lien, J. and Lietava, R. and Likmeta, I. and Lim, B. and Lim, S.H. and Lindenstruth, V. and Lindner, A. and Lindsay, S.W. and Lippmann, C. and Litichevskyi, V. and Liu, A. and Liu, D.H. and Liu, J. and Ljunggren, H.M. and Llope, W.J. and Lofnes, I.M. and Loizides, C. and Lokos, S. and Lombardi Campos, A. and Lombardo, L. and Lomker, J. and Loncar, P. and Lopez, J.A. and Lopez, X. and López Torres, E. and Lu, P. and Luhder, J.R. and Lunardon, M. and Luparello, G. and Lupi, M. and Ma, Y.G. and Maevskaya, A. and Mager, M. and Mahmood, S.M. and Mahmoud, T. and Maire, A. and Majka, R.D. and Makariev, M.V. and Malaev, M. and Malfattore, G. and Malik, N.M. and Malik, Q.W. and Malik, S.K. and Malinina, L. and Mal'Kevich, D. and Mallick, D. and Mallick, N. and Manafov, A. and Mandaglio, G. and Mandal, S.K. and Manen, S.P. and Manko, V. and Manso, F. and Manzari, V. and Mao, Y. and Marchisone, M. and Margagliotti, G.V. and Margotti, A. and Marín, A. and Markert, C. and Markey, G. and Marras, D. and Martinengo, P. and Martinez, J.L. and Martínez, M.I. and Martinez, S. and Martínez García, G. and Martins, T.A. and Masciocchi, S. and Masera, M. and Masoni, A. and Massacrier, L. and Mastroserio, A. and Mathis, A.M. and Mathon, B.S. and Matonoha, O. and Matsuyama, Y. and Matuoka, P.F.T. and Matyja, A. and Mayer, C. and Mazuecos, A.L. and Mazza, G. and Mazzaro, D. and Mazzaschi, F. and Mazzilli, M. and McAlpine, L. and Mdhluli, J.E. and Mechler, A.F. and Melikyan, Y. and Menchaca-Rocha, A. and Meninno, E. and Menon, A.S. and Meres, M. and Mereu, P. and Mhlanga, S. and Miake, Y. and Micheletti, L. and Migliorin, L.C. and Mihaylov, D.L. and Mikhaylov, K. and Miller, N.J. and Mishra, A.N. and Miśkowiec, D. and Mittelstaedt, T. and Modak, A. and Mohanty, A.P. and Mohanty, B. and Mohisin Khan, M. and Molander, M.A. and Montali, L.S. and Moraes, D.M. and Morant, J. and Moravcova, Z. and Mordasini, C. and Moreira De Godoy, D.A. and Morel, F. and Morhardt, T. and Morozov, I. and Morral, P. and Morsch, A. and Mrnjavac, T. and Muccifora, V. and Muhuri, S. and Muley, S.O. and Mulligan, J.D. and Mulliri, A. and Munhoz, M.G. and Münning, K. and Munzer, R.H. and Murakami, H. and Murray, M.R.M. and Murray, S. and Musa, L. and Musinsky, J. and Myrcha, J.W. and Naik, B. and Nambrath, A.I. and Nandi, B.K. and Nania, R. and Nappi, E. and Nassirpour, A.F. and Natal da Luz, H. and Nath, A. and Nattrass, C. and Naydenov, M.N. and Neagu, A. and Negrao De Oliveira, R.A. and Negru, A. and Nellen, L. and Nesbo, S.V. and Neskovic, G. and Nesterov, D. and Nielsen, B.S. and Nielsen, E.G. and Nikolaev, S. and Nikulin, S. and Nikulin, V. and Noferini, F. and Noh, S. and Nomokonov, P. and Norman, J. and Novitzky, N. and Nowakowski, P. and Nyanin, A. and Nystrand, J. and Oberegger, M. and Ogino, M. and Ohlson, A. and Okorokov, V.A. and Oleniacz, J. and Oliveira Da Silva, A.C. and Oliveira Weber, T. and Oliver, M.H. and Onnerstad, A. and Oppedisano, C. and Orlando, A. and Ortiz Velasquez, A. and Oskarsson, A. and Österman, L. and Ottnad, J. and Otwinowski, J. and Oya, M. and Oyama, K. and Pachmayer, Y. and Padhan, S. and Pagano, D. and Paić, G. and Palasciano, A. and Panebianco, S. and Panero, R. and Paoletti, E. and Parasole, O. and Park, H. and Park, H. and Park, J. and Parkkila, J.E. and Passamonti, L. and Pastore, C. and Pathak, S.P. and Patra, R.N. and Paul, B. and Pei, H. and Peitzmann, T. and Pellegrino, F. and Peng, X. and Pennisi, M. and Pepato, A. and Pereira, L.G. and Peresunko, D. and Perez, G.M. and Perrin, S. and Peskov, V. and Pestov, Y. and Petráček, V. and Petris, M. and Petrov, V. and Petrovici, M. and Petta, C. and Pezzi, R.P. and Piano, S. and Pichot, P. and Pierluigi, D. and Pikna, M. and Pillot, P. and Pinazza, O. and Pinsky, L. and Pinto, C. and Pisano, S. and Płoskoń, M. and Planinic, M. and Pliquett, F. and Poblocki, M.T. and Poghosyan, M.G. and Polichtchouk, B. and Politano, S. and Poljak, N. and Pompei, F. and Pop, A. and Porteboeuf-Houssais, S. and Pozdniakov, V. and Pradhan, K.K. and Prakasa, E. and Prasad, S.K. and Prasad, S. and Preghenella, R. and Prino, F. and Prodan, L. and Protsenko, M. and Pruitt, J.R. and Pruneau, C.A. and Pshenichnov, I. and Puccio, M. and Pucillo, S. and Pugelova, Z. and Puggioni, C. and Puleo, E. and Qiu, S. and Quaglia, L. and Quishpe, R.E. and Rachevski, A. and Radu, A.B. and Radulescu, L. and Ragoni, S. and Rak, J. and Rakotozafindrabe, A. and Rambeaud, S. and Ramello, L. and Rami, F. and Ramirez, S.A.R. and Ramirez Jimenez, R. and Rancien, T.A. and Rasa, M. and Räsänen, S.S. and Rasson, J. and Rath, R. and Ratza, V. and Rauch, M.P. and Ravasenga, I. and Read, K.F. and Reckziegel, C. and Redelbach, A.R. and Redlich, K. and Reetz, C.A. and Rehman, A. and Reidt, F. and Reme-Ness, H.A. and Renfordt, R. and Renard, C. and Rescakova, Z. and Reygers, K. and Riabov, A. and Riabov, V. and Ricci, R. and Riccio, C. and Richter, M. and Riedel, A.A. and Riegler, W. and Ristea, C. and Rodríguez Cahuantzi, M. and Røed, K. and Rogalev, R. and Rogochaya, E. and Rogoschinski, T.S. and Rohr, D. and Röhrich, D. and Rojas, P.F. and Rojas Torres, S. and Rokita, P.S. and Romanenko, G. and Ronchetti, F. and Rosano, A. and Rosas, E.D. and Roshchin, E. and Roslon, K. and Rossewij, M.J. and Rossi, A. and Roy, A. and Roy, S. and Rubini, N. and Rubio, E. and Rudzki, T.T. and Ruggiano, D. and Rui, R. and Rumyantsev, B. and Russek, P.G. and Russo, A. and Russo, R. and Rustamov, A. and Rusu, A. and Ryabinkin, E. and Ryabov, Y. and Rybalchenko, A. and Rybicki, A. and Rytkonen, H. and Rzesa, W. and Saarimaki, O.A.M. and Sacc`a, G. and Sacchetti, M. and Sadek, R. and Sadhu, S. and Sadikin, R. and Sadovsky, S. and Saetre, J. and Šafařík, K. and Saha, S.K. and Saha, S. and Sahin, M.O. and Sahoo, B. and Sahoo, R. and Sahoo, S. and Sahu, D. and Sahu, P.K. and Saini, J. and Sajdakova, K. and Sakai, S. and Saleh, M.A. and Salvan, M.P. and Sambyal, S. and Sanchez Gonzalez, A. and Sanna, I. and Saramela, T.B. and Sarkar, D. and Sarkar, N. and Sarma, P. and Sarritzu, V. and Sarti, V.M. and Sas, M.H.P. and Schambach, J. and Scheid, H.S. and Schiaua, C. and Schibler, E. and Schicker, R. and Schmah, A. and Schmidt, C. and Schmidt, H.R. and Schmidt, M.O. and Schmidt, M. and Schmidt, N.V. and Schmier, A.R. and Schotter, R. and Schröter, A. and Schukraft, J. and Schulte, H. and Schwarz, K. and Schweda, K. and Scioli, G. and Scomparin, E. and Secouet, P.J. and Seger, J.E. and Seguna, C. and Sekiguchi, Y. and Sekihata, D. and Selyuzhenkov, I. and Senyukov, S. and Seo, J.J. and Serebryakov, D. and Šerkšnytė, L. and Sevcenco, A. and Shaba, T.J. and Shabetai, A. and Shahoyan, R. and Shangaraev, A. and Sharma, A. and Sharma, B. and Sharma, D. and Sharma, H. and Sharma, M. and Sharma, S. and Sharma, S. and Sharma, U. and Shatat, A. and Shaukat, S. and Sheibani, O. and Shigaki, K. and Shimizu, N. and Shimomura, M. and Shin, J. and Shirinkin, S. and Shou, Q. and Sibiriak, Y. and Siddhanta, S. and Siebig, S. and Sielewicz, K.M. and Siemiarczuk, T. and Silva, T.F. and Silvermyr, D. and Simantathammakul, T. and Simatovic, G. and Simeonov, R. and Simonetti, G. and Simpson, D. and Singh, B. and Singh, B. and Singh, R. and Singh, R. and Singh, R. and Singh, S. and Singh, V.K. and Singhal, V. and Sinha, T. and Sitar, B. and Sitta, M. and Skaali, T.B. and Skorodumovs, G. and Slupecki, M. and Smirnov, N. and Snellings, R.J.M. and Snellman, T.W. and Snoeys, W. and Solheim, E.H. and Soltveit, H.K. and Song, J. and Songmoolnak, A. and Soramel, F. and Sorensen, S.P. and Soto Camacho, R. and Sozzi, F. and Soulet, C. and Spijkers, R. and Sputowska, I. and Staa, J. and Stachel, J. and Stan, I. and Steffanic, P.J. and Stiefelmaier, S.F. and Stocco, D. and Storehaug, I. and Stratmann, P. and Strazzi, S. and Stylianidis, C.P. and Suaide, A.A.P. and Suire, C. and Sukhanov, M. and Suljic, M. and Sultanov, R. and Sumberia, V. and Sumowidagdo, S. and Sun, D. and Sun, X. and Swain, S. and Syed, R.A. and Szabo, A. and Szarka, I. and Szczepankiewicz, A. and Szymkowski, M. and Taghavi, S.F. and Taillepied, G. and Takahashi, J. and Takeuchi, Y. and Tambave, G.J. and Tanaka, Y. and Tang, S. and Tang, Z. and Tapia Takaki, J.D. and Tapus, N. and Tarasovicova, L.A. and Tarzila, M.G. and Tassielli, G.F. and Tauro, A. and Tejeda Muñoz, G. and Telesca, A. and Terasaki, K. and Terlizzi, L. and Terrevoli, C. and Tersimonov, G. and Thakur, S. and Thomas, D. and Thys-Dingou, D.O. and Tikhonov, A. and Timmins, A.R. and Tkacik, M. and Tkacik, T. and Toia, A. and Tokumoto, R. and Topilskaya, N. and Toppi, M. and Torales-Acosta, F. and Tork, T. and Torres Ramos, A.G. and Trifiró, A. and Triolo, A.S. and Tripathy, S. and Tripathy, T. and Trogolo, S. and Trubnikov, V. and Trzaska, W.H. and Trzcinski, T.P. and Tumkin, A. and Turcato, M. and Turpeinen, R. and Tun-Lanoe, K.M.M. and Turrisi, R. and Tuveri, M. and Tveter, T.S. and Tymchuk, I. and Ullaland, K. and Ulukutlu, B. and Umaka, E.N. and Uras, A. and Urioni, M. and Usai, G.L. and Utrobicic, A. and Vala, M. and Valencia Palomo, L. and Valentino, V. and Valle, N. and Van Beelen, J.B. and van Doremalen, L.V.R. and Van Hoorne, J.W. and van Leeuwen, M. and Van Noije, W.A. and van Veen, C.A. and van Weelden, R.J.G. and Vanat, T. and Vande Vyvre, P. and Varga, D. and Varga, Z. and Varga-Kofarago, M. and Vargas, A. and Vargas Hernandez, H. and Vargyas, M. and Varma, R. and Vasileiou, M. and Vasiliev, A. and Vázquez Doce, O. and Vazquez Rueda, O. and Vechernin, V. and Velure, A. and Venier, G. and Vercellin, E. and Vereschagin, S. and Vergara Limón, S. and Vergara Urrutia, L.N. and Vermunt, L. and Veronese, F. and Vértesi, R. and Verweij, M. and Vickovic, L. and Vilakazi, Z. and Villalobos Baillie, O. and Villani, A. and Vino, G. and Vinogradov, A. and Virgili, T. and Virta, M.M.O. and Vislavicius, V. and Vodopyanov, A. and Volkel, B. and Völkl, M.A. and Voloshin, K. and Voloshin, S.A. and Volpe, G. and von Haller, B. and Vorbach, O. and Vorobyev, I. and Voss, B.J.R. and Vozniuk, N. and Vranic, D. and Vrláková, J. and Vuillemin, C. and Vulpescu, B. and Wang, C. and Wang, D. and Wang, Y. and Warmack, B. and Wegrzynek, A. and Weidlich, C.A. and Weiglhofer, F.T. and Wenzel, S.C. and Wessels, J.P. and Weyhmiller, S.L. and Wheadon, R. and Wiechula, J. and Wikne, J. and Wilk, G. and Wilkinson, J. and Willems, G.A. and Windelband, B. and Winkler, S.J. and Winn, M. and Witt, W.E. and Wright, J.R. and Wu, W. and Wu, Y. and Xu, R. and Yadav, A. and Yadav, A.K. and Yalcin, S. and Yamaguchi, Y. and Yang, S. and Yano, S. and Yin, Z. and Yoo, I.-K. and Yoon, J.H. and Yuan, S. and Yuncu, A. and Zabloudil, V. and Zaccolo, V. and Zampolli, C. and Zanone, F. and Zardoshti, N. and Zarochentsev, A. and Závada, P. and Zaviyalov, N. and Zhalov, M. and Zhang, B. and Zhang, E. and Zhang, F. and Zhang, L. and Zhang, S. and Zhang, X. and Zhang, Y. and Zhang, Z. and Zhao, M. and Zherebchevskii, V. and Zhi, Y. and Zhou, D. and Zhou, Y. and Zhu, J. and Zhu, Y. and Zugravel, S.C. and Zurlo, N. and ALICE Collaboration},
+title = {ALICE upgrades during the LHC Long Shutdown 2},
+journal = {Journal of Instrumentation},
+abstract = {A Large Ion Collider Experiment (ALICE) has been conceived and constructed as a heavy-ion experiment at the LHC. During LHC Runs 1 and 2, it has produced a wide range of physics results using all collision systems available at the LHC.  In order to best exploit new physics opportunities opening up with the upgraded LHC and new detector technologies, the experiment has undergone a major upgrade during the LHC Long Shutdown 2 (2019–2022). This comprises the move to continuous readout, the complete overhaul of core detectors, as well as a new online event processing farm with a redesigned online-offline software framework.  These improvements will allow to record Pb-Pb collisions at rates up to 50 kHz, while ensuring sensitivity for signals without a triggerable signature.}
+}
+
+@article{ALLISON2016187,
+title = {Recent developments in Geant4},
+journal = {Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment},
+volume = {835},
+pages = {186-225},
+year = {2016},
+issn = {0168-9002},
+doi = {https://doi.org/10.1016/j.nima.2016.06.125},
+url = {https://www.sciencedirect.com/science/article/pii/S0168900216306957},
+author = {J. Allison and K. Amako and J. Apostolakis and P. Arce and M. Asai and T. Aso and E. Bagli and A. Bagulya and S. Banerjee and G. Barrand and B.R. Beck and A.G. Bogdanov and D. Brandt and J.M.C. Brown and H. Burkhardt and Ph. Canal and D. Cano-Ott and S. Chauvie and K. Cho and G.A.P. Cirrone and G. Cooperman and M.A. Cortés-Giraldo and G. Cosmo and G. Cuttone and G. Depaola and L. Desorgher and X. Dong and A. Dotti and V.D. Elvira and G. Folger and Z. Francis and A. Galoyan and L. Garnier and M. Gayer and K.L. Genser and V.M. Grichine and S. Guatelli and P. Guèye and P. Gumplinger and A.S. Howard and I. Hřivnáčová and S. Hwang and S. Incerti and A. Ivanchenko and V.N. Ivanchenko and F.W. Jones and S.Y. Jun and P. Kaitaniemi and N. Karakatsanis and M. Karamitros and M. Kelsey and A. Kimura and T. Koi and H. Kurashige and A. Lechner and S.B. Lee and F. Longo and M. Maire and D. Mancusi and A. Mantero and E. Mendoza and B. Morgan and K. Murakami and T. Nikitina and L. Pandola and P. Paprocki and J. Perl and I. Petrović and M.G. Pia and W. Pokorski and J.M. Quesada and M. Raine and M.A. Reis and A. Ribon and A. {Ristić Fira} and F. Romano and G. Russo and G. Santin and T. Sasaki and D. Sawkey and J.I. Shin and I.I. Strakovsky and A. Taborda and S. Tanaka and B. Tomé and T. Toshito and H.N. Tran and P.R. Truscott and L. Urban and V. Uzhinsky and J.M. Verbeke and M. Verderi and B.L. Wendt and H. Wenzel and D.H. Wright and D.M. Wright and T. Yamashita and J. Yarba and H. Yoshida},
+keywords = {High energy physics, Nuclear physics, Radiation, Simulation, Computing},
+abstract = {Geant4 is a software toolkit for the simulation of the passage of particles through matter. It is used by a large number of experiments and projects in a variety of application domains, including high energy physics, astrophysics and space science, medical physics and radiation protection. Over the past several years, major changes have been made to the toolkit in order to accommodate the needs of these user communities, and to efficiently exploit the growth of computing power made available by advances in technology. The adaptation of Geant4 to multithreading, advances in physics, detector modeling and visualization, extensions to the toolkit, including biasing and reverse Monte Carlo, and tools for physics and release validation are discussed here.}
+}
+
 @misc{alshehri2024pyhepdev2024workshopsummary,
   title         = {PyHEP.dev 2024 Workshop Summary Report, August 26-30 2024, Aachen, Germany},
   author        = {Azzah Alshehri and Jan Bürger and Saransh Chopra and Niclas Eich and Jonas Eppelt and Martin Erdmann and Jonas Eschle and Peter Fackeldey and Maté Farkas and Matthew Feickert and Tristan Fillinger and Benjamin Fischer and Stefan Fröse and Lino Oscar Gerlach and Nikolai Hartmann and Alexander Heidelbach and Alexander Held and Marian I Ivanov and Josué Molina and Yaroslav Nikitenko and Ianna Osborne and Vincenzo Eduardo Padulano and Jim Pivarski and Cyrille Praz and Marcel Rieger and Eduardo Rodrigues and Oksana Shadura and Juraj Smieško and Giordon Holtsberg Stark and Judith Steinfeld and Angela Warkentin},
@@ -94,6 +178,20 @@
   archiveprefix = {arXiv},
   primaryclass  = {hep-ex},
   url           = {https://arxiv.org/abs/2410.02112}
+}
+
+@article{Alwall:2014hca,
+    author = "Alwall, J. and Frederix, R. and Frixione, S. and Hirschi, V. and Maltoni, F. and Mattelaer, O. and Shao, H. -S. and Stelzer, T. and Torrielli, P. and Zaro, M.",
+    title = "{The automated computation of tree-level and next-to-leading order differential cross sections, and their matching to parton shower simulations}",
+    eprint = "1405.0301",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "CERN-PH-TH-2014-064, CP3-14-18, LPN14-066, MCNET-14-09, ZU-TH-14-14",
+    doi = "10.1007/JHEP07(2014)079",
+    journal = "JHEP",
+    volume = "07",
+    pages = "079",
+    year = "2014"
 }
 
 @article{Alwall:2011uj,
@@ -109,6 +207,97 @@
   volume        = {06},
   pages         = {128},
   year          = {2011}
+}
+
+@misc{ATLAS:2024_hzz_higgs,
+      title={Measurement of off-shell Higgs boson production in the $H^*\rightarrow ZZ\rightarrow 4\ell$ decay channel using a neural simulation-based inference technique in 13 TeV $pp$ collisions with the ATLAS detector}, 
+      author={ATLAS Collaboration},
+      year={2024},
+      eprint={2412.01548},
+      archivePrefix={arXiv},
+      primaryClass={hep-ex},
+      url={https://arxiv.org/abs/2412.01548}, 
+}
+
+@misc{ATLAS:neural_sim_inference,
+      title={An implementation of neural simulation-based inference for parameter estimation in ATLAS}, 
+      author={ATLAS Collaboration},
+      year={2024},
+      eprint={2412.01600},
+      archivePrefix={arXiv},
+      primaryClass={hep-ex},
+      url={https://arxiv.org/abs/2412.01600}, 
+}
+
+@misc{ATLAS:perf_commissioning,
+      title={Configuration, Performance, and Commissioning of the ATLAS $b$-jet Triggers for the 2022 and 2023 LHC data-taking periods}, 
+      author={ATLAS Collaboration},
+      year={2025},
+      eprint={2501.11420},
+      archivePrefix={arXiv},
+      primaryClass={hep-ex},
+      url={https://arxiv.org/abs/2501.11420}, 
+}
+
+@article{ATLAS:trigger_LS3,
+doi = {10.1088/1748-0221/19/06/P06029},
+url = {https://dx.doi.org/10.1088/1748-0221/19/06/P06029},
+year = {2024},
+month = jun,
+publisher = {IOP Publishing},
+volume = {19},
+number = {06},
+pages = {P06029},
+author = {Aad, G. and Aakvaag, E. and Abbott, B. and Abeling, K. and Abicht, N.J. and Abidi, S.H. and Aboulhorma, A. and Abramowicz, H. and Abreu, H. and Abulaiti, Y. and Acharya, B.S. and Adam Bourdarios, C. and Adamczyk, L. and Addepalli, S.V. and Addison, M.J. and Adelman, J. and Adiguzel, A. and Adye, T. and Affolder, A.A. and Afik, Y. and Agaras, M.N. and Agarwala, J. and Aggarwal, A. and Agheorghiesei, C. and Ahmad, A. and Ahmadov, F. and Ahmed, W.S. and Ahuja, S. and Ai, X. and Aielli, G. and Aikot, A. and Ait Tamlihat, M. and Aitbenchikh, B. and Aizenberg, I. and Akbiyik, M. and Åkesson, T.P.A. and Akimov, A.V. and Akiyama, D. and Akolkar, N.N. and Aktas, S. and Al Khoury, K. and Alberghi, G.L. and Albert, J. and Albicocco, P. and Albouy, G.L. and Alderweireldt, S. and Alegria, Z.L. and Aleksa, M. and Aleksandrov, I.N. and Alexa, C. and Alexopoulos, T. and Alfonsi, F. and Algren, M. and Alhroob, M. and Ali, B. and Ali, H.M.J. and Ali, S. and Alibocus, S.W. and Aliev, M. and Alimonti, G. and Alkakhi, W. and Allaire, C. and Allbrooke, B.M.M. and Allen, J.F. and Allendes Flores, C.A. and Allport, P.P. and Aloisio, A. and Alonso, F. and Alpigiani, C. and Alvarez Estevez, M. and Alvarez Fernandez, A. and Alves Cardoso, M. and Alviggi, M.G. and Aly, M. and Amaral Coutinho, Y. and Ambler, A. and Amelung, C. and Amerl, M. and Ames, C.G. and Amidei, D. and Amor Dos Santos, S.P. and Amos, K.R. and Ananiev, V. and Anastopoulos, C. and Andeen, T. and Anders, J.K. and Andrean, S.Y. and Andreazza, A. and Angelidakis, S. and Angerami, A. and Anisenkov, A.V. and Annovi, A. and Antel, C. and Anthony, M.T. and Antipov, E. and Antonelli, M. and Anulli, F. and Aoki, M. and Aoki, T. and Aparisi Pozo, J.A. and Aparo, M.A. and Aperio Bella, L. and Appelt, C. and Apyan, A. and Arbiol Val, S.J. and Arcangeletti, C. and Arce, A.T.H. and Arena, E. and Arguin, J-F. and Argyropoulos, S. and Arling, J.-H. and Arnaez, O. and Arnold, H. and Artoni, G. and Asada, H. and Asai, K. and Asai, S. and Asbah, N.A. and Assamagan, K. and Astalos, R. and Atashi, S. and Atkin, R.J. and Atkinson, M. and Atmani, H. and Atmasiddha, P.A. and Augsten, K. and Auricchio, S. and Auriol, A.D. and Austrup, V.A. and Avolio, G. and Axiotis, K. and Azuelos, G. and Babal, D. and Bachacou, H. and Bachas, K. and Bachiu, A. and Backman, F. and Badea, A. and Baer, T.M. and Bagnaia, P. and Bahmani, M. and Bahner, D. and Bailey, A.J. and Bailey, V.R. and Baines, J.T. and Baines, L. and Baker, O.K. and Bakos, E. and Bakshi Gupta, D. and Balakrishnan, V. and Balasubramanian, R. and Baldin, E.M. and Balek, P. and Ballabene, E. and Balli, F. and Baltes, L.M. and Balunas, W.K. and Balz, J. and Banas, E. and Bandieramonte, M. and Bandyopadhyay, A. and Bansal, S. and Barak, L. and Barakat, M. and Barberio, E.L. and Barberis, D. and Barbero, M. and Barel, M.Z. and Barends, K.N. and Barillari, T. and Barisits, M-S. and Barklow, T. and Baron, P. and Baron Moreno, D.A. and Baroncelli, A. and Barone, G. and Barr, A.J. and Barr, J.D. and Barreiro, F. and Barreiro Guimarães da Costa, J. and Barron, U. and Barros Teixeira, M.G. and Barsov, S. and Bartels, F. and Bartoldus, R. and Barton, A.E. and Bartos, P. and Basan, A. and Baselga, M. and Bassalat, A. and Basso, M.J. and Basson, C.R. and Bates, R.L. and Batlamous, S. and Batley, J.R. and Batool, B. and Battaglia, M. and Battulga, D. and Bauce, M. and Bauer, M. and Bauer, P. and Bazzano Hurrell, L.T. and Beacham, J.B. and Beau, T. and Beaucamp, J.Y. and Beauchemin, P.H. and Bechtle, P. and Beck, H.P. and Becker, K. and Beddall, A.J. and Bednyakov, V.A. and Bee, C.P. and Beemster, L.J. and Beermann, T.A. and Begalli, M. and Begel, M. and Behera, A. and Behr, J.K. and Beirer, J.F. and Beisiegel, F. and Belfkir, M. and Bella, G. and Bellagamba, L. and Bellerive, A. and Bellos, P. and Beloborodov, K. and Benchekroun, D. and Bendebba, F. and Benhammou, Y. and Benkendorfer, K.C. and Beresford, L. and Beretta, M. and Bergeaas Kuutmann, E. and Berger, N. and Bergmann, B. and Beringer, J. and Bernardi, G. and Bernius, C. and Bernlochner, F.U. and Bernon, F. and Berrocal Guardia, A. and Berry, T. and Berta, P. and Berthold, A. and Bertram, I.A. and Bethke, S. and Betti, A. and Bevan, A.J. and Bhalla, N.K. and Bhamjee, M. and Bhatta, S. and Bhattacharya, D.S. and Bhattarai, P. and Bhide, K.D. and Bhopatkar, V.S. and Bianchi, R.M. and Bianco, G. and Biebel, O. and Bielski, R. and Biglietti, M. and Billingsley, C.S. and Bindi, M. and Bingul, A. and Bini, C. and Biondini, A. and Birch-sykes, C.J. and Bird, G.A. and Birman, M. and Biros, M. and Biryukov, S. and Bisanz, T. and Bisceglie, E. and Biswal, J.P. and Biswas, D. and Bjørke, K. and Bloch, I. and Blue, A. and Blumenschein, U. and Blumenthal, J. and Bobrovnikov, V.S. and Boehler, M. and Boehm, B. and Bogavac, D. and Bogdanchikov, A.G. and Bohm, C. and Boisvert, V. and Bokan, P. and Bold, T. and Bomben, M. and Bona, M. and Boonekamp, M. and Booth, C.D. and Borbély, A.G. and Bordulev, I.S. and Borecka-Bielska, H.M. and Borissov, G. and Bortoletto, D. and Boscherini, D. and Bosman, M. and Bossio Sola, J.D. and Bouaouda, K. and Bouchhar, N. and Boudreau, J. and Bouhova-Thacker, E.V. and Boumediene, D. and Bouquet, R. and Boveia, A. and Boyd, J. and Boye, D. and Boyko, I.R. and Bracinik, J. and Brahimi, N. and Brandani, E.D. and Brandt, G. and Brandt, O. and Braren, F. and Brau, B. and Brau, J.E. and Brener, R. and Brenner, L. and Brenner, R. and Bressler, S. and Britton, D. and Britzger, D. and Brock, I. and Brooijmans, G. and Brost, E. and Brown, L.M. and Bruce, L.E. and Bruckler, T.L. and Bruckman de Renstrom, P.A. and Brüers, B. and Bruni, A. and Bruni, G. and Bruschi, M. and Bruscino, N. and Buanes, T. and Buat, Q. and Buchin, D. and Buckley, A.G. and Bulekov, O. and Bullard, B.A. and Burdin, S. and Burgard, C.D. and Burger, A.M. and Burghgrave, B. and Burlayenko, O. and Burr, J.T.P. and Burton, C.D. and Burzynski, J.C. and Busch, E.L. and Büscher, V. and Bussey, P.J. and Butler, J.M. and Buttar, C.M. and Butterworth, J.M. and Buttinger, W. and Buxo Vazquez, C.J. and Buzykaev, A.R. and Cabrera Urbán, S. and Cadamuro, L. and Caforio, D. and Cai, H. and Cai, Y. and Cai, Y. and Cairo, V.M.M. and Cakir, O. and Calace, N. and Calafiura, P. and Calderini, G. and Calfayan, P. and Callea, G. and Caloba, L.P. and Calvet, D. and Calvet, S. and Calvetti, M. and Camacho Toro, R. and Camarda, S. and Camarero Munoz, D. and Camarri, P. and Camerlingo, M.T. and Cameron, D. and Camincher, C. and Campanelli, M. and Camplani, A. and Canale, V. and Cantero, J. and Cao, Y. and Capocasa, F. and Capua, M. and Carbone, A. and Cardarelli, R. and Cardenas, J.C.J. and Cardillo, F. and Carducci, G. and Carli, T. and Carlino, G. and Carlotto, J.I. and Carlson, B.T. and Carlson, E.M. and Carminati, L. and Carnelli, A. and Carnesale, M. and Caron, S. and Carquin, E. and Carrá, S. and Carratta, G. and Carroll, A.M. and Carter, T.M. and Casado, M.P. and Caspar, M. and Castillo, F.L. and Castillo Garcia, L. and Castillo Gimenez, V. and Castro, N.F. and Catinaccio, A. and Catmore, J.R. and Cavaliere, T. and Cavaliere, V. and Cavalli, N. and Cekmecelioglu, Y.C. and Celebi, E. and Cella, S. and Celli, F. and Centonze, M.S. and Cepaitis, V. and Cerny, K. and Cerqueira, A.S. and Cerri, A. and Cerrito, L. and Cerutti, F. and Cervato, B. and Cervelli, A. and Cesarini, G. and Cetin, S.A. and Chakraborty, D. and Chan, J. and Chan, W.Y. and Chapman, J.D. and Chapon, E. and Chargeishvili, B. and Charlton, D.G. and Chatterjee, M. and Chauhan, C. and Che, Y. and Chekanov, S. and Chekulaev, S.V. and Chelkov, G.A. and Chen, A. and Chen, B. and Chen, B. and Chen, H. and Chen, H. and Chen, J. and Chen, J. and Chen, M. and Chen, S. and Chen, S.J. and Chen, X. and Chen, X. and Chen, Y. and Cheng, C.L. and Cheng, H.C. and Cheong, S. and Cheplakov, A. and Cheremushkina, E. and Cherepanova, E. and Cherkaoui El Moursli, R. and Cheu, E. and Cheung, K. and Chevalier, L. and Chiarella, V. and Chiarelli, G. and Chiedde, N. and Chiodini, G. and Chisholm, A.S. and Chitan, A. and Chitishvili, M. and Chizhov, M.V. and Choi, K. and Chou, Y. and Chow, E.Y.S. and Chu, K.L. and Chu, M.C. and Chu, X. and Chudoba, J. and Chwastowski, J.J. and Cieri, D. and Ciesla, K.M. and Cindro, V. and Ciocio, A. and Cirotto, F. and Citron, Z.H. and Citterio, M. and Ciubotaru, D.A. and Clark, A. and Clark, P.J. and Clarry, C. and Clavijo Columbie, J.M. and Clawson, S.E. and Clement, C. and Clercx, J. and Coadou, Y. and Cobal, M. and Coccaro, A. and Coelho Barrue, R.F. and Coelho Lopes De Sa, R. and Coelli, S. and Cole, B. and Collot, J. and Conde Muiño, P. and Connell, M.P. and Connell, S.H. and Connelly, I.A. and Conroy, E.I. and Conventi, F. and Cooke, H.G. and Cooper-Sarkar, A.M. and Cordeiro Oudot Choi, A. and Corpe, L.D. and Corradi, M. and Corriveau, F. and Cortes-Gonzalez, A. and Costa, M.J. and Costanza, F. and Costanzo, D. and Cote, B.M. and Cowan, G. and Cranmer, K. and Cremonini, D. and Crépé-Renaudin, S. and Crescioli, F. and Cristinziani, M. and Cristoforetti, M. and Croft, V. and Crosby, J.E. and Crosetti, G. and Cueto, A. and Cuhadar Donszelmann, T. and Cui, H. and Cui, Z. and Cunningham, W.R. and Curcio, F. and Czodrowski, P. and Czurylo, M.M. and Da Cunha Sargedas De Sousa, M.J. and Da Fonseca Pinto, J.V. and Da Via, C. and Dabrowski, W. and Dado, T. and Dahbi, S. and Dai, T. and Dal Santo, D. and Dallapiccola, C. and Dam, M. and D'amen, G. and D'Amico, V. and Damp, J. and Dandoy, J.R. and Danninger, M. and Dao, V. and Darbo, G. and Darmora, S. and Das, S.J. and D'Auria, S. and David, C. and Davidek, T. and Davis-Purcell, B. and Dawson, I. and Day-hall, H.A. and De, K. and De Asmundis, R. and De Biase, N. and De Castro, S. and De Groot, N. and de Jong, P. and De la Torre, H. and De Maria, A. and De Salvo, A. and De Sanctis, U. and De Santis, F. and De Santo, A. and De Vivie De Regie, J.B. and Dedovich, D.V. and Degens, J. and Deiana, A.M. and Del Corso, F. and Del Peso, J. and Del Rio, F. and Delagrange, L. and Deliot, F. and Delitzsch, C.M. and Della Pietra, M. and Della Volpe, D. and Dell'Acqua, A. and Dell'Asta, L. and Delmastro, M. and Delsart, P.A. and Demers, S. and Demichev, M. and Denisov, S.P. and D'Eramo, L. and Derendarz, D. and Derue, F. and Dervan, P. and Desch, K. and Deutsch, C. and Di Bello, F.A. and Di Ciaccio, A. and Di Ciaccio, L. and Di Domenico, A. and Di Donato, C. and Di Girolamo, A. and Di Gregorio, G. and Di Luca, A. and Di Micco, B. and Di Nardo, R. and Diamantopoulou, M. and Dias, F.A. and Dias Do Vale, T. and Diaz, M.A. and Diaz Capriles, F.G. and Didenko, M. and Diehl, E.B. and Diehl, L. and Díez Cornell, S. and Diez Pardos, C. and Dimitriadi, C. and Dimitrievska, A. and Dingfelder, J. and Dinu, I-M. and Dittmeier, S.J. and Dittus, F. and Djama, F. and Djobava, T. and Doglioni, C. and Dohnalova, A. and Dolejsi, J. and Dolezal, Z. and Dona, K.M. and Donadelli, M. and Dong, B. and Donini, J. and D'Onofrio, A. and D'Onofrio, M. and Dopke, J. and Doria, A. and Dos Santos Fernandes, N. and Dougan, P. and Dova, M.T. and Doyle, A.T. and Draguet, M.A. and Dreyer, E. and Drivas-koulouris, I. and Drnevich, M. and Drozdova, M. and Du, D. and du Pree, T.A. and Dubinin, F. and Dubovsky, M. and Duchovni, E. and Duckeck, G. and Ducu, O.A. and Duda, D. and Dudarev, A. and Duden, E.R. and D'uffizi, M. and Duflot, L. and Dührssen, M. and Dumitriu, A.E. and Dunford, M. and Dungs, S. and Dunne, K. and Duperrin, A. and Duran Yildiz, H. and Düren, M. and Durglishvili, A. and Dwyer, B.L. and Dyckes, G.I. and Dyndal, M. and Dziedzic, B.S. and Earnshaw, Z.O. and Eberwein, G.H. and Eckerova, B. and Eggebrecht, S. and Egidio Purcino De Souza, E. and Ehrke, L.F. and Eigen, G. and Einsweiler, K. and Ekelof, T. and Ekman, P.A. and El Farkh, S. and El Ghazali, Y. and El Jarrari, H. and El Moussaouy, A. and Ellajosyula, V. and Ellert, M. and Ellinghaus, F. and Ellis, N. and Elmsheuser, J. and Elsing, M. and Emeliyanov, D. and Enari, Y. and Ene, I. and Epari, S. and Erland, P.A. and Errenst, M. and Escalier, M. and Escobar, C. and Etzion, E. and Evans, G. and Evans, H. and Evans, L.S. and Evans, M.O. and Ezhilov, A. and Ezzarqtouni, S. and Fabbri, F. and Fabbri, L. and Facini, G. and Fadeyev, V. and Fakhrutdinov, R.M. and Fakoudis, D. and Falciano, S. and Falda Ulhoa Coelho, L.F. and Falke, P.J. and Faltova, J. and Fan, C. and Fan, Y. and Fang, Y. and Fanti, M. and Faraj, M. and Farazpay, Z. and Farbin, A. and Farilla, A. and Farooque, T. and Farrington, S.M. and Fassi, F. and Fassouliotis, D. and Faucci Giannelli, M. and Fawcett, W.J. and Fayard, L. and Federic, P. and Federicova, P. and Fedin, O.L. and Feickert, M. and Feligioni, L. and Fellers, D.E. and Feng, C. and Feng, M. and Feng, Z. and Fenton, M.J. and Ferencz, L. and Ferguson, R.A.M. and Fernandez Luengo, S.I. and Fernandez Martinez, P. and Fernoux, M.J.V. and Ferrando, J. and Ferrari, A. and Ferrari, P. and Ferrari, R. and Ferrere, D. and Ferretti, C. and Fiedler, F. and Fiedler, P. and Filipčič, A. and Filmer, E.K. and Filthaut, F. and Fiolhais, M.C.N. and Fiorini, L. and Fisher, W.C. and Fitschen, T. and Fitzhugh, P.M. and Fleck, I. and Fleischmann, P. and Flick, T. and Flores, M. and Flores Castillo, L.R. and Flores Sanz De Acedo, L. and Follega, F.M. and Fomin, N. and Foo, J.H. and Formica, A. and Forti, A.C. and Fortin, E. and Fortman, A.W. and Foti, M.G. and Fountas, L. and Fournier, D. and Fox, H. and Francavilla, P. and Francescato, S. and Franchellucci, S. and Franchini, M. and Franchino, S. and Francis, D. and Franco, L. and Franco Lima, V. and Franconi, L. and Franklin, M. and Frattari, G. and Freegard, A.C. and Freund, W.S. and Frid, Y.Y. and Friend, J. and Fritzsche, N. and Froch, A. and Froidevaux, D. and Frost, J.A. and Fu, Y. and Fuenzalida Garrido, S. and Fujimoto, M. and Fung, K.Y. and Furtado De Simas Filho, E. and Furukawa, M. and Fuster, J. and Gabrielli, A. and Gabrielli, A. and Gadow, P. and Gagliardi, G. and Gagnon, L.G. and Galantzan, S. and Gallas, E.J. and Gallop, B.J. and Gan, K.K. and Ganguly, S. and Gao, Y. and Garay Walls, F.M. and Garcia, B. and García, C. and Garcia Alonso, A. and Garcia Caffaro, A.G. and García Navarro, J.E. and Garcia-Sciveres, M. and Gardner, G.L. and Gardner, R.W. and Garelli, N. and Garg, D. and Garg, R.B. and Gargan, J.M. and Garner, C.A. and Garvey, C.M. and Gaspar, P. and Gassmann, V.K. and Gaudio, G. and Gautam, V. and Gauzzi, P. and Gavrilenko, I.L. and Gavrilyuk, A. and Gay, C. and Gaycken, G. and Gazis, E.N. and Geanta, A.A. and Gee, C.M. and Gekow, A. and Gemme, C. and Genest, M.H. and Gentry, A.D. and George, S. and George, W.F. and Geralis, T. and Gessinger-Befurt, P. and Geyik, M.E. and Ghani, M. and Ghneimat, M. and Ghorbanian, K. and Ghosal, A. and Ghosh, A. and Ghosh, A. and Giacobbe, B. and Giagu, S. and Giani, T. and Giannetti, P. and Giannini, A. and Gibson, S.M. and Gignac, M. and Gil, D.T. and Gilbert, A.K. and Gilbert, B.J. and Gillberg, D. and Gilles, G. and Ginabat, L. and Gingrich, D.M. and Giordani, M.P. and Giraud, P.F. and Giugliarelli, G. and Giugni, D. and Giuli, F. and Gkialas, I. and Gladilin, L.K. and Glasman, C. and Gledhill, G.R. and Glemža, G. and Glisic, M. and Gnesi, I. and Go, Y. and Goblirsch-Kolb, M. and Gocke, B. and Godin, D. and Gokturk, B. and Goldfarb, S. and Golling, T. and Gololo, M.G.D. and Golubkov, D. and Gombas, J.P. and Gomes, A. and Gomes Da Silva, G. and Gomez Delegido, A.J. and Gonçalo, R. and Gonella, L. and Gongadze, A. and Gonnella, F. and Gonski, J.L. and González Andana, R.Y. and González de la Hoz, S. and Gonzalez Lopez, R. and Gonzalez Renteria, C. and Gonzalez Rodrigues, M.V. and Gonzalez Suarez, R. and Gonzalez-Sevilla, S. and Gonzalvo Rodriguez, G.R. and Goossens, L. and Gorini, B. and Gorini, E. and Gorišek, A. and Gosart, T.C. and Goshaw, A.T. and Gostkin, M.I. and Goswami, S. and Gottardo, C.A. and Gotz, S.A. and Gouighri, M. and Goumarre, V. and Goussiou, A.G. and Govender, N. and Grabowska-Bold, I. and Graham, K. and Gramstad, E. and Grancagnolo, S. and Grant, C.M. and Gravila, P.M. and Gravili, F.G. and Gray, H.M. and Greco, M. and Grefe, C. and Gregor, I.M. and Grenier, P. and Grewe, S.G. and Grieco, C. and Grillo, A.A. and Grimm, K. and Grinstein, S. and Grivaz, J.-F. and Gross, E. and Grosse-Knetter, J. and Grundy, J.C. and Guan, L. and Guan, W. and Gubbels, C. and Guerrero Rojas, J.G.R. and Guerrieri, G. and Guescini, F. and Guest, D. and Gugel, R. and Guhit, J.A.M. and Guida, A. and Guilloton, E. and Guindon, S. and Guo, F. and Guo, J. and Guo, L. and Guo, Y. and Gupta, R. and Gupta, R. and Gurbuz, S. and Gurdasani, S.S. and Gustavino, G. and Guth, M. and Gutierrez, P. and Gutierrez Zagazeta, L.F. and Gutsche, M. and Gutschow, C. and Gwenlan, C. and Gwilliam, C.B. and Haaland, E.S. and Haas, A. and Habedank, M. and Haber, C. and Hadavand, H.K. and Hadef, A. and Hadzic, S. and Hagan, A.I. and Hahn, J.J. and Haines, E.H. and Haleem, M. and Haley, J. and Hall, J.J. and Hallewell, G.D. and Halser, L. and Hamano, K. and Hamer, M. and Hamity, G.N. and Hampshire, E.J. and Han, J. and Han, K. and Han, L. and Han, L. and Han, S. and Han, Y.F. and Hanagaki, K. and Hance, M. and Hangal, D.A. and Hanif, H. and Hank, M.D. and Hansen, J.B. and Hansen, P.H. and Hara, K. and Harada, D. and Harenberg, T. and Harkusha, S. and Harris, M.L. and Harris, Y.T. and Harrison, J. and Harrison, N.M. and Harrison, P.F. and Hartman, N.M. and Hartmann, N.M. and Hasegawa, Y. and Hauser, R. and Hawkes, C.M. and Hawkings, R.J. and Hayashi, Y. and Hayashida, S. and Hayden, D. and Hayes, C. and Hayes, R.L. and Hays, C.P. and Hays, J.M. and Hayward, H.S. and He, F. and He, M. and He, Y. and He, Y. and He, Y. and Heatley, N.B. and Hedberg, V. and Heggelund, A.L. and Hehir, N.D. and Heidegger, C. and Heidegger, K.K. and Heidorn, W.D. and Heilman, J. and Heim, S. and Heim, T. and Heinlein, J.G. and Heinrich, J.J. and Heinrich, L. and Hejbal, J. and Held, A. and Hellesund, S. and Helling, C.M. and Hellman, S. and Henderson, R.C.W. and Henkelmann, L. and Henriques Correia, A.M. and Herde, H. and Hernández Jiménez, Y. and Herrmann, L.M. and Herrmann, T. and Herten, G. and Hertenberger, R. and Hervas, L. and Hesping, M.E. and Hessey, N.P. and Hill, E. and Hillier, S.J. and Hinds, J.R. and Hinterkeuser, F. and Hirose, M. and Hirose, S. and Hirschbuehl, D. and Hitchings, T.G. and Hiti, B. and Hobbs, J. and Hobincu, R. and Hod, N. and Hodgkinson, M.C. and Hodkinson, B.H. and Hoecker, A. and Hofer, D.D. and Hofer, J. and Holm, T. and Holzbock, M. and Hommels, L.B.A.H. and Honan, B.P. and Hong, J. and Hong, T.M. and Hooberman, B.H. and Hopkins, W.H. and Horii, Y. and Hou, S. and Howard, A.S. and Howarth, J. and Hoya, J. and Hrabovsky, M. and Hrynevich, A. and Hryn'ova, T. and Hsu, P.J. and Hsu, S.-C. and Hu, Q. and Hu, Y.F. and Huang, S. and Huang, X. and Huang, X. and Huang, Y. and Huang, Y. and Huang, Z. and Hubacek, Z. and Huebner, M. and Huegging, F. and Huffman, T.B. and Hugli, C.A. and Huhtinen, M. and Huiberts, S.K. and Hulsken, R. and Huseynov, N. and Huston, J. and Huth, J. and Hyneman, R. and Iacobucci, G. and Iakovidis, G. and Ibragimov, I. and Iconomidou-Fayard, L. and Iddon, J.P. and Iengo, P. and Iguchi, R. and Iizawa, T. and Ikegami, Y. and Ilic, N. and Imam, H. and Ince Lezki, M. and Ingebretsen Carlson, T. and Introzzi, G. and Iodice, M. and Ippolito, V. and Irwin, R.K. and Ishino, M. and Islam, W. and Issever, C. and Istin, S. and Ito, H. and Iuppa, R. and Ivina, A. and Izen, J.M. and Izzo, V. and Jacka, P. and Jackson, P. and Jaeger, B.P. and Jagfeld, C.S. and Jain, G. and Jain, P. and Jakobs, K. and Jakoubek, T. and Jamieson, J. and Janas, K.W. and Javurkova, M. and Jeanty, L. and Jejelava, J. and Jenni, P. and Jessiman, C.E. and Jia, C. and Jia, J. and Jia, X. and Jia, X. and Jia, Z. and Jiggins, S. and Jimenez Pena, J. and Jin, S. and Jinaru, A. and Jinnouchi, O. and Johansson, P. and Johns, K.A. and Johnson, J.W. and Jones, D.M. and Jones, E. and Jones, P. and Jones, R.W.L. and Jones, T.J. and Joos, H.L. and Joshi, R. and Jovicevic, J. and Ju, X. and Junggeburth, J.J. and Junkermann, T. and Juste Rozas, A. and Juzek, M.K. and Kabana, S. and Kaczmarska, A. and Kado, M. and Kagan, H. and Kagan, M. and Kahn, A. and Kahn, A. and Kahra, C. and Kaji, T. and Kajomovitz, E. and Kakati, N. and Kalaitzidou, I. and Kalderon, C.W. and Kamenshchikov, A. and Kang, N.J. and Kar, D. and Karava, K. and Kareem, M.J. and Karentzos, E. and Karkanias, I. and Karkout, O. and Karpov, S.N. and Karpova, Z.M. and Kartvelishvili, V. and Karyukhin, A.N. and Kasimi, E. and Katzy, J. and Kaur, S. and Kawade, K. and Kawale, M.P. and Kawamoto, C. and Kawamoto, T. and Kay, E.F. and Kaya, F.I. and Kazakos, S. and Kazanin, V.F. and Ke, Y. and Keaveney, J.M. and Keeler, R. and Kehris, G.V. and Keller, J.S. and Kelly, A.S. and Kempster, J.J. and Kennedy, P.D. and Kepka, O. and Kerridge, B.P. and Kersten, S. and Kerševan, B.P. and Keshri, S. and Keszeghova, L. and Ketabchi Haghighat, S. and Khan, R.A. and Khanov, A. and Kharlamov, A.G. and Kharlamova, T. and Khoda, E.E. and Kholodenko, M. and Khoo, T.J. and Khoriauli, G. and Khubua, J. and Khwaira, Y.A.R. and Kibirige, B. and Kilgallon, A. and Kim, D.W. and Kim, Y.K. and Kimura, N. and Kingston, M.K. and Kirchhoff, A. and Kirfel, C. and Kirfel, F. and Kirk, J. and Kiryunin, A.E. and Kitsaki, C. and Kivernyk, O. and Klassen, M. and Klein, C. and Klein, L. and Klein, M.H. and Klein, S.B. and Klein, U. and Klimek, P. and Klimentov, A. and Klioutchnikova, T. and Kluit, P. and Kluth, S. and Kneringer, E. and Knight, T.M. and Knue, A. and Kobayashi, R. and Kobylianskii, D. and Koch, S.F. and Kocian, M. and Kodyš, P. and Koeck, D.M. and Koenig, P.T. and Koffas, T. and Kolay, O. and Koletsou, I. and Komarek, T. and Köneke, K. and Kong, A.X.Y. and Kono, T. and Konstantinidis, N. and Kontaxakis, P. and Konya, B. and Kopeliansky, R. and Koperny, S. and Korcyl, K. and Kordas, K. and Korn, A. and Korn, S. and Korolkov, I. and Korotkova, N. and Kortman, B. and Kortner, O. and Kortner, S. and Kostecka, W.H. and Kostyukhin, V.V. and Kotsokechagia, A. and Kotwal, A. and Koulouris, A. and Kourkoumeli-Charalampidi, A. and Kourkoumelis, C. and Kourlitis, E. and Kovanda, O. and Kowalewski, R. and Kozanecki, W. and Kozhin, A.S. and Kramarenko, V.A. and Kramberger, G. and Kramer, P. and Krasny, M.W. and Krasznahorkay, A. and Kraus, J.W. and Kremer, J.A. and Kresse, T. and Kretzschmar, J. and Kreul, K. and Krieger, P. and Krishnamurthy, S. and Krivos, M. and Krizka, K. and Kroeninger, K. and Kroha, H. and Kroll, J. and Kroll, J. and Krowpman, K.S. and Kruchonak, U. and Krüger, H. and Krumnack, N. and Kruse, M.C. and Kuchinskaia, O. and Kuday, S. and Kuehn, S. and Kuesters, R. and Kuhl, T. and Kukhtin, V. and Kulchitsky, Y. and Kuleshov, S. and Kumar, M. and Kumari, N. and Kumari, P. and Kupco, A. and Kupfer, T. and Kupich, A. and Kuprash, O. and Kurashige, H. and Kurchaninov, L.L. and Kurdysh, O. and Kurochkin, Y.A. and Kurova, A. and Kuze, M. and Kvam, A.K. and Kvita, J. and Kwan, T. and Kyriacou, N.G. and Laatu, L.A.O. and Lacasta, C. and Lacava, F. and Lacker, H. and Lacour, D. and Lad, N.N. and Ladygin, E. and Laforge, B. and Lagouri, T. and Lahbabi, F.Z. and Lai, S. and Lakomiec, I.K. and Lalloue, N. and Lambert, J.E. and Lammers, S. and Lampl, W. and Lampoudis, C. and Lancaster, A.N. and Lançon, E. and Landgraf, U. and Landon, M.P.J. and Lang, V.S. and Langrekken, O.K.B. and Lankford, A.J. and Lanni, F. and Lantzsch, K. and Lanza, A. and Lapertosa, A. and Laporte, J.F. and Lari, T. and Lasagni Manghi, F. and Lassnig, M. and Latonova, V. and Laudrain, A. and Laurier, A. and Lawlor, S.D. and Lawrence, Z. and Lazaridou, R. and Lazzaroni, M. and Le, B. and Le Boulicaut, E.M. and Leban, B. and Lebedev, A. and LeBlanc, M. and Ledroit-Guillon, F. and Lee, A.C.A. and Lee, S.C. and Lee, S. and Lee, T.F. and Leeuw, L.L. and Lefebvre, H.P. and Lefebvre, M. and Leggett, C. and Lehmann Miotto, G. and Leigh, M. and Leight, W.A. and Leinonen, W. and Leisos, A. and Leite, M.A.L. and Leitgeb, C.E. and Leitner, R. and Leney, K.J.C. and Lenz, T. and Leone, S. and Leonidopoulos, C. and Leopold, A. and Leroy, C. and Les, R. and Lester, C.G. and Levchenko, M. and Levêque, J. and Levinson, L.J. and Levrini, G. and Lewicki, M.P. and Lewis, D.J. and Li, A. and Li, B. and Li, C. and Li, C-Q. and Li, H. and Li, H. and Li, H. and Li, H. and Li, H. and Li, J. and Li, K. and Li, L. and Li, M. and Li, Q.Y. and Li, S. and Li, S. and Li, T. and Li, X. and Li, Z. and Li, Z. and Li, Z. and Liang, S. and Liang, Z. and Liberatore, M. and Liberti, B. and Lie, K. and Lieber Marin, J. and Lien, H. and Lin, K. and Lindley, R.E. and Lindon, J.H. and Lipeles, E. and Lipniacka, A. and Lister, A. and Little, J.D. and Liu, B. and Liu, B.X. and Liu, D. and Liu, J.B. and Liu, J.K.K. and Liu, K. and Liu, M. and Liu, M.Y. and Liu, P. and Liu, Q. and Liu, X. and Liu, X. and Liu, Y. and Liu, Y.L. and Liu, Y.W. and Llorente Merino, J. and Lloyd, S.L. and Lobodzinska, E.M. and Loch, P. and Lohse, T. and Lohwasser, K. and Loiacono, E. and Lokajicek, M. and Lomas, J.D. and Long, J.D. and Longarini, I. and Longo, L. and Longo, R. and Lopez Paz, I. and Lopez Solis, A. and Lorenzo Martinez, N. and Lory, A.M. and Löschcke Centeno, G. and Loseva, O. and Lou, X. and Lou, X. and Lounis, A. and Love, P.A. and Lu, G. and Lu, M. and Lu, S. and Lu, Y.J. and Lubatti, H.J. and Luci, C. and Lucio Alves, F.L. and Luehring, F. and Luise, I. and Lukianchuk, O. and Lundberg, O. and Lund-Jensen, B. and Luongo, N.A. and Lutz, M.S. and Lux, A.B. and Lynn, D. and Lysak, R. and Lytken, E. and Lyubushkin, V. and Lyubushkina, T. and Lyukova, M.M. and Ma, H. and Ma, K. and Ma, L.L. and Ma, W. and Ma, Y. and Mac Donell, D.M. and Maccarrone, G. and MacDonald, J.C. and Machado De Abreu Farias, P.C. and Madar, R. and Mader, W.F. and Madula, T. and Maeda, J. and Maeno, T. and Maguire, H. and Maiboroda, V. and Maio, A. and Maj, K. and Majersky, O. and Majewski, S. and Makovec, N. and Maksimovic, V. and Malaescu, B. and Malecki, Pa. and Maleev, V.P. and Malek, F. and Mali, M. and Malito, D. and Mallik, U. and Maltezos, S. and Malyukov, S. and Mamuzic, J. and Mancini, G. and Mancini, M.N. and Manco, G. and Mandalia, J.P. and Mandić, I. and Manhaes de Andrade Filho, L. and Maniatis, I.M. and Manjarres Ramos, J. and Mankad, D.C. and Mann, A. and Manzoni, S. and Mao, L. and Mapekula, X. and Marantis, A. and Marchiori, G. and Marcisovsky, M. and Marcon, C. and Marinescu, M. and Marium, S. and Marjanovic, M. and Marshall, E.J. and Marshall, Z. and Marti-Garcia, S. and Martin, T.A. and Martin, V.J. and Martin dit Latour, B. and Martinelli, L. and Martinez, M. and Martinez Agullo, P. and Martinez Outschoorn, V.I. and Martinez Suarez, P. and Martin-Haugh, S. and Martoiu, V.S. and Martyniuk, A.C. and Marzin, A. and Mascione, D. and Masetti, L. and Mashimo, T. and Masik, J. and Maslennikov, A.L. and Massarotti, P. and Mastrandrea, P. and Mastroberardino, A. and Masubuchi, T. and Mathisen, T. and Matousek, J. and Matsuzawa, N. and Maurer, J. and Maček, B. and Maximov, D.A. and Mazini, R. and Maznas, I. and Mazza, M. and Mazza, S.M. and Mazzeo, E. and Mc Ginn, C. and Mc Gowan, J.P. and Mc Kee, S.P. and McCracken, C.C. and McDonald, E.F. and McDougall, A.E. and Mcfayden, J.A. and McGovern, R.P. and Mchedlidze, G. and Mckenzie, R.P. and Mclachlan, T.C. and Mclaughlin, D.J. and McMahon, S.J. and Mcpartland, C.M. and McPherson, R.A. and Mehlhase, S. and Mehta, A. and Melini, D. and Mellado Garcia, B.R. and Melo, A.H. and Meloni, F. and Mendes Jacques Da Costa, A.M. and Meng, H.Y. and Meng, L. and Menke, S. and Mentink, M. and Meoni, E. and Mercado, G. and Merlassino, C. and Merola, L. and Meroni, C. and Metcalfe, J. and Mete, A.S. and Meyer, C. and Meyer, J-P. and Middleton, R.P. and Mijović, L. and Mikenberg, G. and Mikestikova, M. and Mikuž, M. and Mildner, H. and Milic, A. and Miller, D.W. and Miller, E.H. and Miller, L.S. and Milov, A. and Milstead, D.A. and Min, T. and Minaenko, A.A. and Minashvili, I.A. and Mince, L. and Mincer, A.I. and Mindur, B. and Mineev, M. and Mino, Y. and Mir, L.M. and Miralles Lopez, M. and Mironova, M. and Mishima, A. and Missio, M.C. and Mitra, A. and Mitsou, V.A. and Mitsumori, Y. and Miu, O. and Miyagawa, P.S. and Mkrtchyan, T. and Mlinarevic, M. and Mlinarevic, T. and Mlynarikova, M. and Mobius, S. and Mogg, P. and Mohamed Farook, M.H. and Mohammed, A.F. and Mohapatra, S. and Mokgatitswane, G. and Moleri, L. and Mondal, B. and Mondal, S. and Mönig, K. and Monnier, E. and Monsonis Romero, L. and Montejo Berlingen, J. and Montella, M. and Montereali, F. and Monticelli, F. and Monzani, S. and Morange, N. and Moreira De Carvalho, A.L. and Moreno Llácer, M. and Moreno Martinez, C. and Morettini, P. and Morgenstern, S. and Morii, M. and Morinaga, M. and Morodei, F. and Morvaj, L. and Moschovakos, P. and Moser, B. and Mosidze, M. and Moskalets, T. and Moskvitina, P. and Moss, J. and Moyse, E.J.W. and Mtintsilana, O. and Muanza, S. and Mueller, J. and Muenstermann, D. and Müller, R. and Mullier, G.A. and Mullin, A.J. and Mullin, J.J. and Mungo, D.P. and Munoz Perez, D. and Munoz Sanchez, F.J. and Murin, M. and Murray, W.J. and Muškinja, M. and Mwewa, C. and Myagkov, A.G. and Myers, A.J. and Myers, G. and Myska, M. and Nachman, B.P. and Nackenhorst, O. and Nagai, K. and Nagano, K. and Nagle, J.L. and Nagy, E. and Nairz, A.M. and Nakahama, Y. and Nakamura, K. and Nakamura, T. and Nakkalil, K. and Nanjo, H. and Narayan, R. and Narayanan, E.A. and Naryshkin, I. and Naseri, M. and Nasri, S. and Nass, C. and Navarro, G. and Navarro-Gonzalez, J. and Nayak, R. and Nayaz, A. and Nechaeva, P.Y. and Nechansky, F. and Nedic, L. and Neep, T.J. and Negri, A. and Negrini, M. and Nellist, C. and Nelson, C. and Nelson, K. and Nemecek, S. and Nessi, M. and Neubauer, M.S. and Neuhaus, F. and Neundorf, J. and Newhouse, R. and Newman, P.R. and Ng, C.W. and Ng, Y.W.Y. and Ngair, B. and Nguyen, H.D.N. and Nickerson, R.B. and Nicolaidou, R. and Nielsen, J. and Niemeyer, M. and Niermann, J. and Nikiforou, N. and Nikolaenko, V. and Nikolic-Audit, I. and Nikolopoulos, K. and Nilsson, P. and Ninca, I. and Nindhito, H.R. and Ninio, G. and Nisati, A. and Nishu, N. and Nisius, R. and Nitschke, J-E. and Nkadimeng, E.K. and Nobe, T. and Noel, D.L. and Nommensen, T. and Norfolk, M.B. and Norisam, R.R.B. and Norman, B.J. and Noury, M. and Novak, J. and Novak, T. and Novotny, L. and Novotny, R. and Nozka, L. and Ntekas, K. and Nunes De Moura Junior, N.M.J. and Nurse, E. and Ocariz, J. and Ochi, A. and Ochoa, I. and Oerdek, S. and Offermann, J.T. and Ogrodnik, A. and Oh, A. and Ohm, C.C. and Oide, H. and Oishi, R. and Ojeda, M.L. and Okumura, Y. and Oleiro Seabra, L.F. and Olivares Pino, S.A. and Oliveira Damazio, D. and Oliveira Goncalves, D. and Oliver, J.L. and Öncel, Ö.O. and O'Neill, A.P. and Onofre, A. and Onyisi, P.U.E. and Oreglia, M.J. and Orellana, G.E. and Orestano, D. and Orlando, N. and Orr, R.S. and O'Shea, V. and Osojnak, L.M. and Ospanov, R. and Otero y Garzon, G. and Otono, H. and Ott, P.S. and Ottino, G.J. and Ouchrif, M. and Ould-Saada, F. and Owen, M. and Owen, R.E. and Oyulmaz, K.Y. and Ozcan, V.E. and Ozturk, F. and Ozturk, N. and Ozturk, S. and Pacey, H.A. and Pacheco Pages, A. and Padilla Aranda, C. and Padovano, G. and Pagan Griso, S. and Palacino, G. and Palazzo, A. and Pampel, J. and Pan, J. and Pan, T. and Panchal, D.K. and Pandini, C.E. and Panduro Vazquez, J.G. and Pandya, H.D. and Pang, H. and Pani, P. and Panizzo, G. and Paolozzi, L. and Parajuli, S. and Paramonov, A. and Paraskevopoulos, C. and Paredes Hernandez, D. and Pareti, A. and Park, K.R. and Park, T.H. and Parker, M.A. and Parodi, F. and Parrish, E.W. and Parrish, V.A. and Parsons, J.A. and Parzefall, U. and Pascual Dias, B. and Pascual Dominguez, L. and Pasqualucci, E. and Passaggio, S. and Pastore, F. and Patel, P. and Patel, U.M. and Pater, J.R. and Pauly, T. and Pazos, C.I. and Pearkes, J. and Pedersen, M. and Pedro, R. and Peleganchuk, S.V. and Penc, O. and Pender, E.A. and Penn, G.D. and Penski, K.E. and Penzin, M. and Peralva, B.S. and Pereira Peixoto, A.P. and Pereira Sanchez, L. and Perepelitsa, D.V. and Perez Codina, E. and Perganti, M. and Pernegger, H. and Perrin, O. and Peters, K. and Peters, R.F.Y. and Petersen, B.A. and Petersen, T.C. and Petit, E. and Petousis, V. and Petridou, C. and Petrukhin, A. and Pettee, M. and Pettersson, N.E. and Petukhov, A. and Petukhova, K. and Pezoa, R. and Pezzotti, L. and Pezzullo, G. and Pham, T.M. and Pham, T. and Phillips, P.W. and Piacquadio, G. and Pianori, E. and Piazza, F. and Piegaia, R. and Pietreanu, D. and Pilkington, A.D. and Pinamonti, M. and Pinfold, J.L. and Pinheiro Pereira, B.C. and Pinto Pinoargote, A.E. and Pintucci, L. and Piper, K.M. and Pirttikoski, A. and Pizzi, D.A. and Pizzimento, L. and Pizzini, A. and Pleier, M.-A. and Plesanovs, V. and Pleskot, V. and Plotnikova, E. and Poddar, G. and Poettgen, R. and Poggioli, L. and Pokharel, I. and Polacek, S. and Polesello, G. and Poley, A. and Polini, A. and Pollard, C.S. and Pollock, Z.B. and Pompa Pacchi, E. and Ponomarenko, D. and Pontecorvo, L. and Popa, S. and Popeneciu, G.A. and Poreba, A. and Portillo Quintero, D.M. and Pospisil, S. and Postill, M.A. and Postolache, P. and Potamianos, K. and Potepa, P.A. and Potrap, I.N. and Potter, C.J. and Potti, H. and Poulsen, T. and Poveda, J. and Pozo Astigarraga, M.E. and Prades Ibanez, A. and Pretel, J. and Price, D. and Primavera, M. and Principe Martin, M.A. and Privara, R. and Procter, T. and Proffitt, M.L. and Proklova, N. and Prokofiev, K. and Proto, G. and Proudfoot, J. and Przybycien, M. and Przygoda, W.W. and Psallidas, A. and Puddefoot, J.E. and Pudzha, D. and Pyatiizbyantseva, D. and Qian, J. and Qichen, D. and Qin, Y. and Qiu, T. and Quadt, A. and Queitsch-Maitland, M. and Quetant, G. and Quinn, R.P. and Rabanal Bolanos, G. and Rafanoharana, D. and Ragusa, F. and Rainbolt, J.L. and Raine, J.A. and Rajagopalan, S. and Ramakoti, E. and Ramirez-Berend, I.A. and Ran, K. and Rapheeha, N.P. and Rasheed, H. and Raskina, V. and Rassloff, D.F. and Rastogi, A. and Rave, S. and Ravina, B. and Ravinovich, I. and Raymond, M. and Read, A.L. and Readioff, N.P. and Rebuzzi, D.M. and Redlinger, G. and Reed, A.S. and Reeves, K. and Reidelsturz, J.A. and Reikher, D. and Rej, A. and Rembser, C. and Renda, M. and Rendel, M.B. and Renner, F. and Rennie, A.G. and Rescia, A.L. and Resconi, S. and Ressegotti, M. and Rettie, S. and Reyes Rivera, J.G. and Reynolds, E. and Rezanova, O.L. and Reznicek, P. and Riani, H. and Ribaric, N. and Ricci, E. and Richter, R. and Richter, S. and Richter-Was, E. and Ridel, M. and Ridouani, S. and Rieck, P. and Riedler, P. and Riefel, E.M. and Rieger, J.O. and Rijssenbeek, M. and Rimoldi, M. and Rinaldi, L. and Rinn, T.T. and Rinnagel, M.P. and Ripellino, G. and Riu, I. and Rivera Vergara, J.C. and Rizatdinova, F. and Rizvi, E. and Roberts, B.A. and Roberts, B.R. and Robertson, S.H. and Robinson, D. and Robles Gajardo, C.M. and Robles Manzano, M. and Robson, A. and Rocchi, A. and Roda, C. and Rodriguez Bosca, S. and Rodriguez Garcia, Y. and Rodriguez Rodriguez, A. and Rodríguez Vera, A.M. and Roe, S. and Roemer, J.T. and Roepe-Gier, A.R. and Roggel, J. and Røhne, O. and Rojas, R.A. and Roland, C.P.A. and Roloff, J. and Romaniouk, A. and Romano, E. and Romano, M. and Romero Hernandez, A.C. and Rompotis, N. and Roos, L. and Rosati, S. and Rosser, B.J. and Rossi, E. and Rossi, E. and Rossi, L.P. and Rossini, L. and Rosten, R. and Rotaru, M. and Rottler, B. and Rougier, C. and Rousseau, D. and Rousso, D. and Roy, A. and Roy-Garand, S. and Rozanov, A. and Rozario, Z.M.A. and Rozen, Y. and Rubio Jimenez, A. and Ruby, A.J. and Ruelas Rivera, V.H. and Ruggeri, T.A. and Ruggiero, A. and Ruiz-Martinez, A. and Rummler, A. and Rurikova, Z. and Rusakovich, N.A. and Russell, H.L. and Russo, G. and Rutherfoord, J.P. and Rutherford Colmenares, S. and Rybacki, K. and Rybar, M. and Rye, E.B. and Ryzhov, A. and Sabater Iglesias, J.A. and Sabatini, P. and Sadrozinski, H.F-W. and Safai Tehrani, F. and Safarzadeh Samani, B. and Safdari, M. and Saha, S. and Sahinsoy, M. and Saibel, A. and Saimpert, M. and Saito, M. and Saito, T. and Salamani, D. and Salnikov, A. and Salt, J. and Salvador Salas, A. and Salvatore, D. and Salvatore, F. and Salzburger, A. and Sammel, D. and Sampsonidis, D. and Sampsonidou, D. and Sánchez, J. and Sanchez Sebastian, V. and Sandaker, H. and Sander, C.O. and Sandesara, J.A. and Sandhoff, M. and Sandoval, C. and Sankey, D.P.C. and Sano, T. and Sansoni, A. and Santi, L. and Santoni, C. and Santos, H. and Santra, A. and Saoucha, K.A. and Saraiva, J.G. and Sardain, J. and Sarkar, A. and Sasaki, O. and Sato, K. and Sauer, C. and Sauerburger, F. and Sauvan, E. and Savard, P. and Sawada, R. and Sawyer, C. and Sawyer, L. and Sayago Galvan, I. and Sbarra, C. and Sbrizzi, A. and Scanlon, T. and Schaarschmidt, J. and Schäfer, U. and Schaffer, A.C. and Schaile, D. and Schamberger, R.D. and Scharf, C. and Schefer, M.M. and Schegelsky, V.A. and Scheirich, D. and Schenck, F. and Schernau, M. and Scheulen, C. and Schiavi, C. and Schioppa, E.J. and Schioppa, M. and Schlag, B. and Schleicher, K.E. and Schlenker, S. and Schmeing, J. and Schmidt, M.A. and Schmieden, K. and Schmitt, C. and Schmitt, N. and Schmitt, S. and Schoeffel, L. and Schoening, A. and Scholer, P.G. and Schopf, E. and Schott, M. and Schovancova, J. and Schramm, S. and Schroer, T. and Schultz-Coulon, H-C. and Schumacher, M. and Schumm, B.A. and Schune, Ph. and Schuy, A.J. and Schwartz, H.R. and Schwartzman, A. and Schwarz, T.A. and Schwemling, Ph. and Schwienhorst, R. and Sciandra, A. and Sciolla, G. and Scuri, F. and Sebastiani, C.D. and Sedlaczek, K. and Seema, P. and Seidel, S.C. and Seiden, A. and Seidlitz, B.D. and Seitz, C. and Seixas, J.M. and Sekhniaidze, G. and Selem, L. and Semprini-Cesari, N. and Sengupta, D. and Senthilkumar, V. and Serin, L. and Serkin, L. and Sessa, M. and Severini, H. and Sforza, F. and Sfyrla, A. and Sha, Q. and Shabalina, E. and Shaheen, R. and Shahinian, J.D. and Shaked Renous, D. and Shan, L.Y. and Shapiro, M. and Sharma, A. and Sharma, A.S. and Sharma, P. and Shatalov, P.B. and Shaw, K. and Shaw, S.M. and Shcherbakova, A. and Shen, Q. and Sheppard, D.J. and Sherwood, P. and Shi, L. and Shi, X. and Shimmin, C.O. and Shinner, J.D. and Shipsey, I.P.J. and Shirabe, S. and Shiyakova, M. and Shlomi, J. and Shochet, M.J. and Shojaii, J. and Shope, D.R. and Shrestha, B. and Shrestha, S. and Shrif, E.M. and Shroff, M.J. and Sicho, P. and Sickles, A.M. and Sideras Haddad, E. and Sidoti, A. and Siegert, F. and Sijacki, Dj. and Sili, F. and Silva, J.M. and Silva Oliveira, M.V. and Silverstein, S.B. and Simion, S. and Simoniello, R. and Simpson, E.L. and Simpson, H. and Simpson, L.R. and Simpson, N.D. and Simsek, S. and Sindhu, S. and Sinervo, P. and Singh, S. and Sinha, S. and Sinha, S. and Sioli, M. and Siral, I. and Sitnikova, E. and Sjölin, J. and Skaf, A. and Skorda, E. and Skubic, P. and Slawinska, M. and Smakhtin, V. and Smart, B.H. and Smirnov, S.Yu. and Smirnov, Y. and Smirnova, L.N. and Smirnova, O. and Smith, A.C. and Smith, E.A. and Smith, H.A. and Smith, J.L. and Smith, R. and Smizanska, M. and Smolek, K. and Snesarev, A.A. and Snider, S.R. and Snoek, H.L. and Snyder, S. and Sobie, R. and Soffer, A. and Solans Sanchez, C.A. and Soldatov, E.Yu. and Soldevila, U. and Solodkov, A.A. and Solomon, S. and Soloshenko, A. and Solovieva, K. and Solovyanov, O.V. and Solovyev, V. and Sommer, P. and Sonay, A. and Song, W.Y. and Sopczak, A. and Sopio, A.L. and Sopkova, F. and Sorenson, J.D. and Sotarriva Alvarez, I.R. and Sothilingam, V. and Soto Sandoval, O.J. and Sottocornola, S. and Soualah, R. and Soumaimi, Z. and South, D. and Soybelman, N. and Spagnolo, S. and Spalla, M. and Sperlich, D. and Spigo, G. and Spinali, S. and Spiteri, D.P. and Spousta, M. and Staats, E.J. and Stamen, R. and Stampekis, A. and Standke, M. and Stanecka, E. and Stange, M.V. and Stanislaus, B. and Stanitzki, M.M. and Stapf, B. and Starchenko, E.A. and Stark, G.H. and Stark, J. and Staroba, P. and Starovoitov, P. and Stärz, S. and Staszewski, R. and Stavropoulos, G. and Steentoft, J. and Steinberg, P. and Stelzer, B. and Stelzer, H.J. and Stelzer-Chilton, O. and Stenzel, H. and Stevenson, T.J. and Stewart, G.A. and Stewart, J.R. and Stockton, M.C. and Stoicea, G. and Stolarski, M. and Stonjek, S. and Straessner, A. and Strandberg, J. and Strandberg, S. and Stratmann, M. and Strauss, M. and Strebler, T. and Strizenec, P. and Ströhmer, R. and Strom, D.M. and Stroynowski, R. and Strubig, A. and Stucci, S.A. and Stugu, B. and Stupak, J. and Styles, N.A. and Su, D. and Su, S. and Su, W. and Su, X. and Sugizaki, K. and Sulin, V.V. and Sullivan, M.J. and Sultan, D.M.S. and Sultanaliyeva, L. and Sultansoy, S. and Sumida, T. and Sun, S. and Sun, S. and Sunneborn Gudnadottir, O. and Sur, N. and Sutton, M.R. and Suzuki, H. and Svatos, M. and Swiatlowski, M. and Swirski, T. and Sykora, I. and Sykora, M. and Sykora, T. and Ta, D. and Tackmann, K. and Taffard, A. and Tafirout, R. and Tafoya Vargas, J.S. and Takubo, Y. and Talby, M. and Talyshev, A.A. and Tam, K.C. and Tamir, N.M. and Tanaka, A. and Tanaka, J. and Tanaka, R. and Tanasini, M. and Tao, Z. and Tapia Araya, S. and Tapprogge, S. and Tarek Abouelfadl Mohamed, A. and Tarem, S. and Tariq, K. and Tarna, G. and Tartarelli, G.F. and Tas, P. and Tasevsky, M. and Tassi, E. and Tate, A.C. and Tateno, G. and Tayalati, Y. and Taylor, G.N. and Taylor, W. and Tee, A.S. and Teixeira De Lima, R. and Teixeira-Dias, P. and Teoh, J.J. and Terashi, K. and Terron, J. and Terzo, S. and Testa, M. and Teuscher, R.J. and Thaler, A. and Theiner, O. and Themistokleous, N. and Theveneaux-Pelzer, T. and Thielmann, O. and Thomas, D.W. and Thomas, J.P. and Thompson, E.A. and Thompson, P.D. and Thomson, E. and Tian, Y. and Tikhomirov, V. and Tikhonov, Yu.A. and Timoshenko, S. and Timoshyn, D. and Ting, E.X.L. and Tipton, P. and Tlou, S.H. and Tnourji, A. and Todome, K. and Todorova-Nova, S. and Todt, S. and Togawa, M. and Tojo, J. and Tokár, S. and Tokushuku, K. and Toldaiev, O. and Tombs, R. and Tomoto, M. and Tompkins, L. and Topolnicki, K.W. and Torrence, E. and Torres, H. and Torró Pastor, E. and Toscani, M. and Tosciri, C. and Tost, M. and Tovey, D.R. and Traeet, A. and Trandafir, I.S. and Trefzger, T. and Tricoli, A. and Trigger, I.M. and Trincaz-Duvoid, S. and Trischuk, D.A. and Trocmé, B. and Truong, L. and Trzebinski, M. and Trzupek, A. and Tsai, F. and Tsai, M. and Tsiamis, A. and Tsiareshka, P.V. and Tsigaridas, S. and Tsirigotis, A. and Tsiskaridze, V. and Tskhadadze, E.G. and Tsopoulou, M. and Tsujikawa, Y. and Tsukerman, I.I. and Tsulaia, V. and Tsuno, S. and Tsuri, K. and Tsybychev, D. and Tu, Y. and Tudorache, A. and Tudorache, V. and Tuna, A.N. and Turchikhin, S. and Turk Cakir, I. and Turra, R. and Turtuvshin, T. and Tuts, P.M. and Tzamarias, S. and Tzanis, P. and Tzovara, E. and Ukegawa, F. and Ulloa Poblete, P.A. and Umaka, E.N. and Unal, G. and Unal, M. and Undrus, A. and Unel, G. and Urban, J. and Urquijo, P. and Urrejola, P. and Usai, G. and Ushioda, R. and Usman, M. and Uysal, Z. and Vacek, V. and Vachon, B. and Vadla, K.O.H. and Vafeiadis, T. and Vaitkus, A. and Valderanis, C. and Valdes Santurio, E. and Valente, M. and Valentinetti, S. and Valero, A. and Valiente Moreno, E. and Vallier, A. and Valls Ferrer, J.A. and Van Arneman, D.R. and Van Daalen, T.R. and Van Der Graaf, A. and Van Gemmeren, P. and Van Rijnbach, M. and Van Stroud, S. and Van Vulpen, I. and Vanadia, M. and Vandelli, W. and Vandewall, E.R. and Vannicola, D. and Vannoli, L. and Vari, R. and Varnes, E.W. and Varni, C. and Varol, T. and Varouchas, D. and Varriale, L. and Varvell, K.E. and Vasile, M.E. and Vaslin, L. and Vasquez, G.A. and Vasyukov, A. and Vavricka, R. and Vazeille, F. and Vazquez Schroeder, T. and Veatch, J. and Vecchio, V. and Veen, M.J. and Veliscek, I. and Veloce, L.M. and Veloso, F. and Veneziano, S. and Ventura, A. and Ventura Gonzalez, S. and Verbytskyi, A. and Verducci, M. and Vergis, C. and Verissimo De Araujo, M. and Verkerke, W. and Vermeulen, J.C. and Vernieri, C. and Vessella, M. and Vetterli, M.C. and Vgenopoulos, A. and Viaux Maira, N. and Vickey, T. and Vickey Boeriu, O.E. and Viehhauser, G.H.A. and Vigani, L. and Villa, M. and Villaplana Perez, M. and Villhauer, E.M. and Vilucchi, E. and Vincter, M.G. and Virdee, G.S. and Vishwakarma, A. and Visibile, A. and Vittori, C. and Vivarelli, I. and Voevodina, E. and Vogel, F. and Voigt, J.C. and Vokac, P. and Volkotrub, Yu. and Von Ahnen, J. and Von Toerne, E. and Vormwald, B. and Vorobel, V. and Vorobev, K. and Vos, M. and Voss, K. and Vozak, M. and Vozdecky, L. and Vranjes, N. and Vranjes Milosavljevic, M. and Vreeswijk, M. and Vu, N.K. and Vuillermet, R. and Vujinovic, O. and Vukotic, I. and Wada, S. and Wagner, C. and Wagner, J.M. and Wagner, W. and Wahdan, S. and Wahlberg, H. and Wakida, M. and Walder, J. and Walker, R. and Walkowiak, W. and Wall, A. and Wamorkar, T. and Wang, A.Z. and Wang, C. and Wang, C. and Wang, H. and Wang, J. and Wang, R.-J. and Wang, R. and Wang, R. and Wang, S.M. and Wang, S. and Wang, T. and Wang, W.T. and Wang, W. and Wang, X. and Wang, X. and Wang, X. and Wang, Y. and Wang, Y. and Wang, Z. and Wang, Z. and Wang, Z. and Warburton, A. and Ward, R.J. and Warrack, N. and Waterhouse, S. and Watson, A.T. and Watson, H. and Watson, M.F. and Watton, E. and Watts, G. and Waugh, B.M. and Weber, C. and Weber, H.A. and Weber, M.S. and Weber, S.M. and Wei, C. and Wei, Y. and Weidberg, A.R. and Weik, E.J. and Weingarten, J. and Weirich, M. and Weiser, C. and Wells, C.J. and Wenaus, T. and Wendland, B. and Wengler, T. and Wenke, N.S. and Wermes, N. and Wessels, M. and Wharton, A.M. and White, A.S. and White, A. and White, M.J. and Whiteson, D. and Wickremasinghe, L. and Wiedenmann, W. and Wielers, M. and Wiglesworth, C. and Wilbern, D.J. and Wilkens, H.G. and Williams, D.M. and Williams, H.H. and Williams, S. and Willocq, S. and Wilson, B.J. and Windischhofer, P.J. and Winkel, F.I. and Winklmeier, F. and Winter, B.T. and Winter, J.K. and Wittgen, M. and Wobisch, M. and Wolffs, Z. and Wollrath, J. and Wolter, M.W. and Wolters, H. and Woodward, E.L. and Worm, S.D. and Wosiek, B.K. and Woźniak, K.W. and Wozniewski, S. and Wraight, K. and Wu, C. and Wu, J. and Wu, M. and Wu, M. and Wu, S.L. and Wu, X. and Wu, Y. and Wu, Z. and Wuerzinger, J. and Wyatt, T.R. and Wynne, B.M. and Xella, S. and Xia, L. and Xia, M. and Xiang, J. and Xie, M. and Xie, X. and Xin, S. and Xiong, A. and Xiong, J. and Xu, D. and Xu, H. and Xu, L. and Xu, R. and Xu, T. and Xu, Y. and Xu, Z. and Xu, Z. and Yabsley, B. and Yacoob, S. and Yamaguchi, Y. and Yamashita, E. and Yamashita, T. and Yamauchi, H. and Yamazaki, T. and Yamazaki, Y. and Yan, J. and Yan, S. and Yan, Z. and Yang, H.J. and Yang, H.T. and Yang, S. and Yang, T. and Yang, X. and Yang, X. and Yang, Y. and Yang, Y. and Yang, Z. and Yao, W-M. and Ye, H. and Ye, H. and Ye, J. and Ye, S. and Ye, X. and Yeh, Y. and Yeletskikh, I. and Yeo, B.K. and Yexley, M.R. and Yin, P. and Yorita, K. and Younas, S. and Young, C.J.S. and Young, C. and Yu, C. and Yu, Y. and Yuan, M. and Yuan, R. and Yue, L. and Zaazoua, M. and Zabinski, B. and Zaid, E. and Zak, Z.K. and Zakareishvili, T. and Zakharchuk, N. and Zambito, S. and Zamora Saa, J.A. and Zang, J. and Zanzi, D. and Zaplatilek, O. and Zeitnitz, C. and Zeng, H. and Zeng, J.C. and Zenger Jr, D.T. and Zenin, O. and Ženiš, T. and Zenz, S. and Zerradi, S. and Zerwas, D. and Zhai, M. and Zhang, D.F. and Zhang, J. and Zhang, J. and Zhang, K. and Zhang, L. and Zhang, P. and Zhang, R. and Zhang, S. and Zhang, S. and Zhang, T. and Zhang, X. and Zhang, X. and Zhang, Y. and Zhang, Y. and Zhang, Y. and Zhang, Z. and Zhang, Z. and Zhao, H. and Zhao, T. and Zhao, Y. and Zhao, Z. and Zhemchugov, A. and Zheng, J. and Zheng, K. and Zheng, X. and Zheng, Z. and Zhong, D. and Zhou, B. and Zhou, H. and Zhou, N. and Zhou, Y. and Zhou, Y. and Zhu, C.G. and Zhu, J. and Zhu, Y. and Zhu, Y. and Zhuang, X. and Zhukov, K. and Zimine, N.I. and Zinsser, J. and Ziolkowski, M. and Živković, L. and Zoccoli, A. and Zoch, K. and Zorbas, T.G. and Zormpa, O. and Zou, W. and Zwalinski, L. and The ATLAS collaboration},
+title = {The ATLAS trigger system for LHC Run 3 and trigger performance in 2022},
+journal = {Journal of Instrumentation},
+abstract = {The ATLAS trigger system is a crucial component of the ATLAS experiment at the LHC. It is responsible for selecting events in line with the ATLAS physics programme. This paper presents an overview of the changes to the trigger and data acquisition system during the second long shutdown of the LHC, and shows the performance of the trigger system and its components in the proton-proton collisions during the 2022 commissioning period as well as its expected performance in proton-proton and heavy-ion collisions for the remainder of the third LHC data-taking period (2022–2025).}
+}
+
+@article{Andersen:2020sjs,
+    author = {Andersen, Jeppe R. and G\"utschow, Christian and Maier, Andreas and Prestel, Stefan},
+    title = "{A Positive Resampler for Monte Carlo events with negative weights}",
+    eprint = "2005.09375",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "DCPT/20/30, DESY-20-090, DESY 20-090, IPPP/20/15, LU-TP-20-21, MCNET-20-14, SAGEX-20-12, MCNET-20-14,
+  SAGEX-20-12",
+    doi = "10.1140/epjc/s10052-020-08548-w",
+    journal = "Eur. Phys. J. C",
+    volume = "80",
+    number = "11",
+    pages = "1007",
+    year = "2020"
+}
+
+@article{Andersen:2021mvw,
+    author = "Andersen, Jeppe R. and Maier, Andreas",
+    title = "{Unbiased elimination of negative weights in Monte Carlo samples}",
+    eprint = "2109.07851",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "DCPT/21/54, DESY 21-135, IPPP/21/27, MCNET-21-14, SAGEX-21-29",
+    doi = "10.1140/epjc/s10052-022-10372-3",
+    journal = "Eur. Phys. J. C",
+    volume = "82",
+    number = "5",
+    pages = "433",
+    year = "2022"
+}
+
+@article{Bierlich:2023fmh,
+    author = "Bierlich, Christian and Ilten, Philip and Menzo, Tony and Mrenna, Stephen and Szewc, Manuel and Wilkinson, Michael K. and Youssef, Ahmed and Zupan, Jure",
+    title = "{Reweighting Monte Carlo predictions and automated fragmentation variations in Pythia 8}",
+    eprint = "2308.13459",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "FERMILAB-PUB-23-414-CSAID",
+    doi = "10.21468/SciPostPhys.16.5.134",
+    journal = "SciPost Phys.",
+    volume = "16",
+    number = "5",
+    pages = "134",
+    year = "2024"
 }
 
 @article{Bertone:2019hks,
@@ -127,6 +316,31 @@
   note          = {[Erratum: JHEP 08, 108 (2022)]}
 }
 
+@article{Bothmann:2023gew,
+    author = {Bothmann, Enrico and Childers, Taylor and Giele, Walter and H\"oche, Stefan and Isaacson, Joshua and Knobbe, Max},
+    title = "{A portable parton-level event generator for the high-luminosity LHC}",
+    eprint = "2311.06198",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "FERMILAB-PUB-23-641-T, MCNET-23-18",
+    doi = "10.21468/SciPostPhys.17.3.081",
+    journal = "SciPost Phys.",
+    volume = "17",
+    number = "3",
+    pages = "081",
+    year = "2024"
+}
+
+@misc{campbell2024eg,
+      title={Event Generators for High-Energy Physics Experiments}, 
+      author={J. M. Campbell and M. Diefenthaler and T. J. Hobbs and S. Höche and J. Isaacson and F. Kling and S. Mrenna and J. Reuter and S. Alioli and J. R. Andersen and C. Andreopoulos and A. M. Ankowski and E. C. Aschenauer and A. Ashkenazi and M. D. Baker and J. L. Barrow and M. van Beekveld and G. Bewick and S. Bhattacharya and C. Bierlich and E. Bothmann and P. Bredt and A. Broggio and A. Buckley and A. Butter and J. M. Butterworth and E. P. Byrne and C. M. Carloni Calame and S. Chakraborty and X. Chen and M. Chiesa and J. T. Childers and J. Cruz-Martinez and J. Currie and N. Darvishi and M. Dasgupta and A. Denner and F. A. Dreyer and S. Dytman and B. K. El-Menoufi and T. Engel and S. Ferrario Ravasio and D. Figueroa and L. Flower and J. R. Forshaw and R. Frederix and A. Friedland and S. Frixione and H. Gallagher and K. Gallmeister and S. Gardiner and R. Gauld and J. Gaunt and A. Gavardi and T. Gehrmann and A. Gehrmann-De Ridder and L. Gellersen and W. Giele and S. Gieseke and F. Giuli and E. W. N. Glover and M. Grazzini and A. Grohsjean and C. Gütschow and K. Hamilton and T. Han and R. Hatcher and G. Heinrich and I. Helenius and O. Hen and V. Hirschi and M. Höfer and J. Holguin and A. Huss and P. Ilten and S. Jadach and A. Jentsch and S. P. Jones and W. Ju and S. Kallweit and A. Karlberg and T. Katori and M. Kerner and W. Kilian and M. M. Kirchgaeßer and S. Klein and M. Knobbe and C. Krause and F. Krauss and J. Lang and J. -N. Lang and G. Lee and S. W. Li and M. A. Lim and J. M. Lindert and D. Lombardi and L. Lönnblad and M. Löschner and N. Lurkin and Y. Ma and P. Machado and V. Magerya and A. Maier and I. Majer and F. Maltoni and M. Marcoli and G. Marinelli and M. R. Masouminia and P. Mastrolia and O. Mattelaer and J. Mazzitelli and J. McFayden and R. Medves and P. Meinzinger and J. Mo and P. F. Monni and G. Montagna and T. Morgan and U. Mosel and B. Nachman and P. Nadolsky and R. Nagar and Z. Nagy and D. Napoletano and P. Nason and T. Neumann and L. J. Nevay and O. Nicrosini and J. Niehues and K. Niewczas and T. Ohl and G. Ossola and V. Pandey and A. Papadopoulou and A. Papaefstathiou and G. Paz and M. Pellen and G. Pelliccioli and T. Peraro and F. Piccinini and L. Pickering and J. Pires and W. Płaczek and S. Plätzer and T. Plehn and S. Pozzorini and S. Prestel and C. T. Preuss and A. C. Price and S. Quackenbush and E. Re and D. Reichelt and L. Reina and C. Reuschle and P. Richardson and M. Rocco and N. Rocco and M. Roda and A. Rodriguez Garcia and S. Roiser and J. Rojo and L. Rottoli and G. P. Salam and M. Schönherr and S. Schuchmann and S. Schumann and R. Schürmann and L. Scyboz and M. H. Seymour and F. Siegert and A. Signer and G. Singh Chahal and A. Siódmok and T. Sjöstrand and P. Skands and J. M. Smillie and J. T. Sobczyk and D. Soldin and D. E. Soper and A. Soto-Ontoso and G. Soyez and G. Stagnitto and J. Tena-Vidal and O. Tomalak and F. Tramontano and S. Trojanowski and Z. Tu and S. Uccirati and T. Ullrich and Y. Ulrich and M. Utheim and A. Valassi and A. Verbytskyi and R. Verheyen and M. Wagman and D. Walker and B. R. Webber and L. Weinstein and O. White and J. Whitehead and M. Wiesemann and C. Wilkinson and C. Williams and R. Winterhalder and C. Wret and K. Xie and T-Z. Yang and E. Yazgan and G. Zanderighi and S. Zanoli and K. Zapp},
+      year={2024},
+      eprint={2203.11110},
+      archivePrefix={arXiv},
+      primaryClass={hep-ph},
+      url={https://arxiv.org/abs/2203.11110}, 
+}
+
 @article{CarloniCalame:2003yt,
   author        = {Carloni Calame, C. M. and Montagna, G. and Nicrosini, O.
                    and Piccinini, F.},
@@ -141,6 +355,11 @@
   year          = {2004}
 }
 
+@online{CERN:computing_school,
+  title = {CERN School of Computing},
+  url = {https://csc.web.cern.ch}
+}
+
 @techreport{CERN-LHCC-2022-005,
   collaboration = {ATLAS},
   title         = {{ATLAS Software and Computing HL-LHC Roadmap}},
@@ -151,11 +370,59 @@
   url           = {https://cds.cern.ch/record/2802918}
 }
 
+@online{CERN:SW_workshops,
+  title = {CERN OpenLab Software Workshops},
+  url = {https://indico.cern.ch/category/3169/}
+}
+
+@article{CMS:Detector_R3,
+doi = {10.1088/1748-0221/19/05/P05064},
+url = {https://dx.doi.org/10.1088/1748-0221/19/05/P05064},
+year = {2024},
+month = may,
+publisher = {IOP Publishing},
+volume = {19},
+number = {05},
+pages = {P05064},
+author = {Hayrapetyan, A. and Tumasyan, A. and Adam, W. and Andrejkovic, J.W. and Arnold, B. and Bergauer, H. and Bergauer, T. and Chatterjee, S. and Damanakis, K. and Dragicevic, M. and Escalante Del Valle, A. and Hussain, P.S. and Jeitler, M. and Krammer, N. and Liko, D. and Mikulec, I. and Schieck, J. and Schöfbeck, R. and Schwarz, D. and Sonawane, M. and Templ, S. and Waltenberger, W. and Wulz, C.-E. and Darwish, M.R. and Janssen, T. and Van Mechelen, P. and Bols, E.S. and D'Hondt, J. and Dansana, S. and De Moor, A. and Delcourt, M. and El Faham, H. and Lowette, S. and Makarenko, I. and Morton, A. and Müller, D. and Sahasransu, A.R. and Tavernier, S. and Tytgat, M. and Van Putte, S. and Vannerom, D. and Clerbaux, B. and De Lentdecker, G. and Favart, L. and Hohov, D. and Jaramillo, J. and Khalilzadeh, A. and Lee, K. and Mahdavikhorrami, M. and Malara, A. and Paredes, S. and Pétré, L. and Postiau, N. and Thomas, L. and Vanden Bemden, M. and Vander Velde, C. and Vanlaer, P. and De Coen, M. and Dobur, D. and Knolle, J. and Lambrecht, L. and Mestdach, G. and Rendón, C. and Samalan, A. and Skovpen, K. and Van Den Bossche, N. and Vermassen, B. and Wezenbeek, L. and Benecke, A. and Bruno, G. and Caputo, C. and Delaere, C. and Donertas, I.S. and Giammanco, A. and Jaffel, K. and Jain, Sa. and Lemaitre, V. and Lidrych, J. and Mastrapasqua, P. and Mondal, K. and Tran, T.T. and Wertz, S. and Alves, G.A. and Coelho, E. and Hensel, C. and Menezes De Oliveira, T. and Moraes, A. and Rebello Teles, P. and Soeiro, M. and Aldá Júnior, W.L. and Alves Gallo Pereira, M. and Barroso Ferreira Filho, M. and Brandao Malbouisson, H. and Carvalho, W. and Chinellato, J. and Da Costa, E.M. and Da Silveira, G.G. and De Jesus Damiao, D. and Fonseca De Souza, S. and Martins, J. and Mora Herrera, C. and Mota Amarilo, K. and Mundim, L. and Nogima, H. and Santoro, A. and Silva Do Amaral, S.M. and Sznajder, A. and Thiel, M. and Vilela Pereira, A. and Bernardes, C.A. and Calligaris, L. and Fernandez Perez Tomei, T.R. and Gregores, E.M. and Mercadante, P.G. and Novaes, S.F. and Orzari, B. and Padula, Sandra S. and Aleksandrov, A. and Antchev, G. and Hadjiiska, R. and Iaydjiev, P. and Misheva, M. and Shopova, M. and Sultanov, G. and Dimitrov, A. and Ivanov, T. and Litov, L. and Pavlov, B. and Petkov, P. and Petrov, A. and Shumka, E. and Keshri, S. and Thakur, S. and Cheng, T. and Guo, Q. and Javaid, T. and Mittal, M. and Yuan, L. and Bauer, G. and Hu, Z. and Yi, K. and Chen, G.M. and Chen, H.S. and Chen, M. and Iemmi, F. and Jiang, C.H. and Kapoor, A. and Liao, H. and Liu, Z.-A. and Monti, F. and Sharma, R. and Song, J.N. and Tao, J. and Wang, J. and Zhang, H. and Agapitos, A. and Ban, Y. and Levin, A. and Li, C. and Li, Q. and Lyu, X. and Mao, Y. and Qian, S.J. and Sun, X. and Wang, D. and Yang, H. and Zhou, C. and You, Z. and Lu, N. and Gao, X. and Leggat, D. and Okawa, H. and Zhang, Y. and Lin, Z. and Lu, C. and Xiao, M. and Avila, C. and Barbosa Trujillo, D.A. and Cabrera, A. and Florez, C. and Fraga, J. and Reyes Vega, J.A. and Mejia Guisao, J. and Ramirez, F. and Rodriguez, M. and Ruiz Alvarez, J.D. and Giljanovic, D. and Godinovic, N. and Lelas, D. and Sculac, A. and Kovac, M. and Sculac, T. and Bargassa, P. and Brigljevic, V. and Chitroda, B.K. and Ferencek, D. and Mishra, S. and Starodumov, A. and Susa, T. and Attikis, A. and Christoforou, K. and Konstantinou, S. and Mousa, J. and Nicolaou, C. and Ptochos, F. and Razis, P.A. and Rykaczewski, H. and Saka, H. and Stepennov, A. and Finger, M. and Finger, M. and Kveton, A. and Ayala, E. and Cardenas, A. and Carrera Jarrin, E. and Cazar Ramírez, D. and Mendez Garces, E.F. and Riofrio, X. and Assran, Y. and Elgammal, S. and Abdullah Al-Mashad, M. and Mahmoud, M.A. and Dewanjee, R.K. and Ehataht, K. and Kadastik, M. and Lange, T. and Nandan, S. and Nielsen, C. and Pata, J. and Raidal, M. and Tani, L. and Veelken, C. and Kirschenmann, H. and Osterberg, K. and Voutilainen, M. and Bharthuar, S. and Brücken, E. and Garcia, F. and Havukainen, J. and Kallonen, K.T.S. and Kim, M.S. and Kinnunen, R. and Koponen, P.P. and Lampén, T. and Lassila-Perini, K. and Lehti, S. and Lindén, T. and Lotti, M. and Martikainen, L. and Myllymäki, M. and Rantanen, M.m. and Siikonen, H. and Tuominen, E. and Tuominiemi, J. and Turpeinen, R. and Luukka, P. and Petrow, H. and Tuuva, T. and Besancon, M. and Couderc, F. and Dejardin, M. and Denegri, D. and Faure, J.L. and Ferri, F. and Ganjour, S. and Gras, P. and Hamel de Monchenault, G. and Lohezic, V. and Malcles, J. and Rander, J. and Rosowsky, A. and Sahin, M.Ö. and Savoy-Navarro, A. and Simkina, P. and Titov, M. and Baldenegro Barrera, C. and Beaudette, F. and Buchot Perraguin, A. and Busson, P. and Cappati, A. and Charlot, C. and Chiron, A. and Damas, F. and Davignon, O. and Falmagne, G. and Fontana Santos Alves, B.A. and Ghosh, S. and Gilbert, A. and Granier de Cassagnac, R. and Hakimi, A. and Harikrishnan, B. and Kalipoliti, L. and Liu, G. and Motta, J. and Nguyen, M. and Ochando, C. and Portales, L. and Romanteau, T. and Salerno, R. and Sarkar, U. and Sauvan, J.B. and Sirois, Y. and Tarabini, A. and Vernazza, E. and Zabi, A. and Zghiche, A. and Agram, J.-L. and Andrea, J. and Apparu, D. and Bloch, D. and Brom, J.-M. and Chabert, E.C. and Charles, L. and Collard, C. and Falke, S. and Goerlach, U. and Grimault, C. and Gross, L. and Haeberle, R. and Le Bihan, A.-C. and Sessini, M.A. and Van Hove, P. and Baulieu, G. and Beauceron, S. and Blancon, B. and Boudoul, G. and Chanon, N. and Choi, J. and Contardo, D. and Depasse, P. and Dozen, C. and El Mamouni, H. and Fay, J. and Gascon, S. and Gouzevitch, M. and Greenberg, C. and Grenier, G. and Ille, B. and Laktineh, I.B. and Lethuillier, M. and Lumb, N. and Mirabito, L. and Perries, S. and Pugnere, D. and Schirra, F. and Vander Donckt, M. and Verdier, P. and Xiao, J. and Adamov, G. and Bagaturia, I. and Chokheli, D. and Kemularia, O. and Khvedelidze, A. and Lomidze, D. and Lomidze, I. and Melkadze, A. and Toriashvili, T. and Tsamalaidze, Z. and Autermann, C. and Botta, V. and Feld, L. and Karpinski, W. and Kiesel, M.K. and Klein, K. and Lipinski, M. and Meuser, D. and Pauls, A. and Pierschel, G. and Rauch, M.P. and Röwert, N. and Schomakers, C. and Schulz, J. and Teroerde, M. and Wlochal, M. and Diekmann, S. and Dodonova, A. and Eich, N. and Eliseev, D. and Engelke, F. and Erdmann, M. and Fackeldey, P. and Fischer, B. and Hebbeker, T. and Hoepfner, K. and Ivone, F. and Jung, A. and Lee, M.y. and Mastrolorenzo, L. and Merschmeyer, M. and Meyer, A. and Mukherjee, S. and Noll, D. and Novak, A. and Nowotny, F. and Pozdnyakov, A. and Rath, Y. and Redjeb, W. and Rehm, F. and Reithler, H. and Sarkisovi, V. and Schmidt, A. and Schuler, S.C. and Sharma, A. and Stein, A. and Torres Da Silva De Araujo, F. and Vigilante, L. and Wiedenbeck, S. and Zaleski, S. and Dziwok, C. and Flügge, G. and Haj Ahmad, W. and Kress, T. and Nowack, A. and Pooth, O. and Stahl, A. and Ziemons, T. and Zotz, A. and Aarup Petersen, H. and Aldaya Martin, M. and Alimena, J. and Amoroso, S. and An, Y. and Baxter, S. and Bayatmakou, M. and Becerril Gonzalez, H. and Behnke, O. and Belvedere, A. and Bhattacharya, S. and Blekman, F. and Borras, K. and Brunner, D. and Campbell, A. and Cardini, A. and Cheng, C. and Colombina, F. and Consuegra Rodríguez, S. and Correia Silva, G. and De Silva, M. and Eckerlin, G. and Eckstein, D. and Estevez Banos, L.I. and Filatov, O. and Gallo, E. and Geiser, A. and Giraldi, A. and Greau, G. and Guglielmi, V. and Guthoff, M. and Hinzmann, A. and Jafari, A. and Jeppe, L. and Jomhari, N.Z. and Jung, H. and Kaech, B. and Kasemann, M. and Kaveh, H. and Kleinwort, C. and Kogler, R. and Komm, M. and Krücker, D. and Lange, W. and Leyva Pernia, D. and Lipka, K. and Lohmann, W. and Mankel, R. and Melzer-Pellmann, I.-A. and Mendizabal Morentin, M. and Metwally, J. and Meyer, A.B. and Milella, G. and Mormile, M. and Mussgiller, A. and Nürnberg, A. and Otarid, Y. and Pérez Adán, D. and Ranken, E. and Raspereza, A. and Ribeiro Lopes, B. and Rübenach, J. and Saggio, A. and Scham, M. and Scheurer, V. and Schnake, S. and Schütze, P. and Schwanenberger, C. and Shchedrolosiev, M. and Sosa Ricardo, R.E. and Sreelatha Pramod, L.P. and Stafford, D. and Vazzoler, F. and Ventura Barroso, A. and Walsh, R. and Wang, Q. and Wen, Y. and Wichmann, K. and Wiens, L. and Wissing, C. and Wuchterl, S. and Yang, Y. and Zimermmane Castro Santos, A. and Albrecht, A. and Albrecht, S. and Antonello, M. and Bein, S. and Benato, L. and Bonanomi, M. and Connor, P. and Eich, M. and El Morabit, K. and Fischer, Y. and Fröhlich, A. and Garbers, C. and Garutti, E. and Grohsjean, A. and Hajheidari, M. and Haller, J. and Jabusch, H.R. and Kasieczka, G. and Keicher, P. and Klanner, R. and Korcari, W. and Kramer, T. and Kutzner, V. and Labe, F. and Lange, J. and Lobanov, A. and Matthies, C. and Mehta, A. and Moureaux, L. and Mrowietz, M. and Nigamova, A. and Nissan, Y. and Paasch, A. and Pena Rodriguez, K.J. and Quadfasel, T. and Raciti, B. and Rieger, M. and Savoiu, D. and Schindler, J. and Schleper, P. and Schröder, M. and Schwandt, J. and Sommerhalder, M. and Stadie, H. and Steinbrück, G. and Tews, A. and Wolf, M. and Brommer, S. and Burkart, M. and Butz, E. and Chwalek, T. and Dierlamm, A. and Droll, A. and Faltermann, N. and Giffels, M. and Gottmann, A. and Hartmann, F. and Horzela, M. and Husemann, U. and Klute, M. and Koppenhöfer, R. and Link, M. and Lintuluoto, A. and Maier, S. and Mitra, S. and Müller, Th. and Neukum, M. and Oh, M. and Quast, G. and Rabbertz, K. and Shvetsov, I. and Simonis, H.J. and Trevisani, N. and Ulrich, R. and van der Linden, J. and Von Cube, R.F. and Wassmer, M. and Wieland, S. and Wittig, F. and Wolf, R. and Wunsch, S. and Zuo, X. and Anagnostou, G. and Assiouras, P. and Daskalakis, G. and Kyriakis, A. and Papadopoulos, A. and Stakia, A. and Karasavvas, D. and Kontaxakis, P. and Melachroinos, G. and Panagiotou, A. and Papavergou, I. and Paraskevas, I. and Saoulidou, N. and Theofilatos, K. and Tziaferi, E. and Vellidis, K. and Zisopoulos, I. and Bakas, G. and Chatzistavrou, T. and Karapostoli, G. and Kousouris, K. and Papakrivopoulos, I. and Siamarkou, E. and Tsipolitis, G. and Zacharopoulou, A. and Adamidis, K. and Bestintzanos, I. and Evangelou, I. and Foudas, C. and Gianneios, P. and Kamtsikis, C. and Katsoulis, P. and Kokkas, P. and Kosmoglou Kioseoglou, P.G. and Manthos, N. and Papadopoulos, I. and Strologas, J. and Csanád, M. and Farkas, K. and Gadallah, M.M.A. and Kadlecsik, Á. and Major, P. and Mandal, K. and Pásztor, G. and Rádl, A.J. and Surányi, O. and Veres, G.I. and Bartók, M. and Hajdu, C. and Horvath, D. and Sikler, F. and Veszpremi, V. and Bencze, G. and Czellar, S. and Karancsi, J. and Molnar, J. and Szillasi, Z. and Raics, P. and Ujvari, B. and Zilizi, G. and Csorgo, T. and Nemes, F. and Novak, T. and Babbar, J. and Bansal, S. and Beri, S.B. and Bhatnagar, V. and Chaudhary, G. and Chauhan, S. and Dhingra, N. and Gupta, R. and Kaur, A. and Kaur, A. and Kaur, H. and Kaur, M. and Kumar, S. and Kumari, P. and Meena, M. and Sandeep, K. and Sheokand, T. and Singh, J.B. and Singla, A. and Ahmed, A. and Bhardwaj, A. and Chhetri, A. and Choudhary, B.C. and Kumar, A. and Naimuddin, M. and Ranjan, K. and Saumya, S. and Baradia, S. and Barman, S. and Bhattacharya, S. and Bhowmik, D. and Dutta, S. and Dutta, S. and Gomber, B. and Palit, P. and Saha, G. and Sahu, B. and Sarkar, S. and Behera, P.K. and Behera, S.C. and Chatterjee, S. and Jana, P. and Kalbhor, P. and Komaragiri, J.R. and Kumar, D. and Mohammad Mobassir Ameen, M. and Panwar, L. and Pradhan, R. and Pujahari, P.R. and Saha, N.R. and Sharma, A. and Sikdar, A.K. and Verma, S. and Aziz, T. and Das, I. and Dugad, S. and Kumar, M. and Mohanty, G.B. and Suryadevara, P. and Bala, A. and Banerjee, S. and Chatterjee, R.M. and Guchait, M. and Karmakar, S. and Kumar, S. and Majumder, G. and Mazumdar, K. and Mukherjee, S. and Thachayath, A. and Bahinipati, S. and Das, A.K. and Kar, C. and Maity, D. and Mal, P. and Mishra, T. and Muraleedharan Nair Bindhu, V.K. and Naskar, K. and Nayak, A. and Sadangi, P. and Saha, P. and Swain, S.K. and Varghese, S. and Vats, D. and Alpana, A. and Dube, S. and Kansal, B. and Laha, A. and Pandey, S. and Rastogi, A. and Sharma, S. and Bakhshiansohi, H. and Khazaie, E. and Zeinali, M. and Chenarani, S. and Etesami, S.M. and Khakzad, M. and Mohammadi Najafabadi, M. and Felcini, M. and Grunewald, M. and Abbrescia, M. and Aly, R. and Colaleo, A. and Creanza, D. and D` Anzi, B. and De Filippis, N. and De Palma, M. and De Robertis, G. and Di Florio, A. and Elmetenawee, W. and Fiore, L. and Franco, M. and Iaselli, G. and Licciulli, F. and Loddo, F. and Maggi, G. and Maggi, M. and Margjeka, I. and Mastrapasqua, V. and My, S. and Nuzzo, S. and Pellecchia, A. and Pompili, A. and Pugliese, G. and Radogna, R. and Ramirez-Sanchez, G. and Ramos, D. and Ranieri, A. and Silvestris, L. and Simone, F.M. and Sözbilir, Ü. and Stamerra, A. and Venditti, R. and Verwilligen, P. and Zaza, A. and Abbiendi, G. and Baldanza, C. and Battilana, C. and Bonacorsi, D. and Borgonovi, L. and Cafaro, V.D. and Capiluppi, P. and Castro, A. and Cavallo, F.R. and Crupano, A. and Cuffiani, M. and Dallavalle, G.M. and Diotalevi, T. and Fabbri, F. and Fanfani, A. and Fasanella, D. and Giacomelli, P. and Giommi, L. and Giordano, V. and Grandi, C. and Guandalini, C. and Guiducci, L. and Lo Meo, S. and Lunerti, L. and Marcellini, S. and Masetti, G. and Navarria, F.L. and Perrotta, A. and Primavera, F. and Rossi, A.M. and Rovelli, T. and Siroli, G.P. and Costa, S. and Di Mattia, A. and Potenza, R. and Tricomi, A. and Tuve, C. and Barbagli, G. and Bardelli, G. and Camaiani, B. and Cassese, A. and Ceccarelli, R. and Ciulli, V. and Civinini, C. and D'Alessandro, R. and Focardi, E. and Latino, G. and Lenzi, P. and Lizzo, M. and Meschini, M. and Paoletti, S. and Papanastassiou, A. and Sguazzoni, G. and Viliani, L. and Benussi, L. and Bianco, S. and Caponero, M. and Meola, S. and Piccolo, D. and Saviano, G. and Cerchi, S. and Chatagnon, P. and Ferro, F. and Puppo, R. and Robutti, E. and Rossi, C. and Tosi, S. and Trovato, A. and Benaglia, A. and Boldrini, G. and Brivio, F. and Cetorelli, F. and De Guio, F. and Dinardo, M.E. and Dini, P. and Gennai, S. and Ghezzi, A. and Govoni, P. and Guzzi, L. and Lucchini, M.T. and Malberti, M. and Malvezzi, S. and Massironi, A. and Menasce, D. and Moroni, L. and Paganoni, M. and Pedrini, D. and Pinolini, B.S. and Ragazzi, S. and Redaelli, N. and Tabarelli de Fatis, T. and Zuolo, D. and Buontempo, S. and Cagnotta, A. and Carnevali, F. and Cavallo, N. and De Iorio, A. and Fabozzi, F. and Iorio, A.O.M. and Lista, L. and Paolucci, P. and Rossi, B. and Sciacca, C. and Ardino, R. and Azzi, P. and Bacchetta, N. and Barcellan, L. and Bellato, M. and Benettoni, M. and Bergnoli, A. and Berti, L. and Biasotto, M. and Bisello, D. and Bortignon, P. and Bragagnolo, A. and Carlin, R. and Castellani, L. and Checchia, P. and Ciano, L. and Colombo, A. and Corti, D. and Crescente, A. and Dorigo, T. and Fantinel, S. and Fanzago, F. and Gasparini, F. and Gasparini, U. and Gonella, F. and Gozzelino, A. and Griggio, A. and Grosso, G. and Gulmini, M. and Isocrate, R. and Layer, L. and Lusiani, E. and Margoni, M. and Maron, G. and Meneguzzo, A.T. and Michelotto, M. and Migliorini, M. and Modenese, L. and Montecassiano, F. and Negrello, M. and Passaseo, M. and Pazzini, J. and Ramina, L. and Rampazzo, M. and Rebeschini, M. and Ronchese, P. and Rossin, R. and Sgaravatto, M. and Simonetto, F. and Strong, G. and Temporin, R. and Tessaro, M. and Toffano, M. and Toniolo, N. and Tosi, M. and Triossi, A. and Ventura, S. and Yarar, H. and Zanetti, M. and Zatti, P.G. and Zotto, P. and Zucchetta, A. and Zumerle, G. and Abu Zeid, S. and Aimè, C. and Braghieri, A. and Calzaferri, S. and Fiorina, D. and Montagna, P. and Re, V. and Riccardi, C. and Salvini, P. and Vai, I. and Vitulo, P. and Ajmal, S. and Asenov, P. and Baldinelli, G. and Bianchi, F. and Bilei, G.M. and Bizzaglia, S. and Checcucci, B. and Ciangottini, D. and Fanò, L. and Farnesini, L. and Ionica, M. and Magherini, M. and Mantovani, G. and Mariani, V. and Menichelli, M. and Morozzi, A. and Moscatelli, F. and Passeri, D. and Piccinelli, A. and Placidi, P. and Presilla, M. and Rossi, A. and Santocchia, A. and Spiga, D. and Tedeschi, T. and Turrioni, C. and Azzurri, P. and Bagliesi, G. and Basti, A. and Bhattacharya, R. and Bianchini, L. and Bitossi, M. and Boccali, T. and Borrello, L. and Bosi, F. and Bossini, E. and Bruschini, D. and Castaldi, R. and Ciocci, M.A. and Cipriani, M. and D'Amante, V. and Dell'Orso, R. and Donato, S. and Fiori, F. and Giassi, A. and Ligabue, F. and Magazzu, G. and Massa, M. and Matos Figueiredo, D. and Messineo, A. and Moggi, A. and Musich, M. and Palla, F. and Palmonari, F. and Parolia, S. and Raffaelli, F. and Rizzi, A. and Rolandi, G. and Roy Chowdhury, S. and Sarkar, T. and Scribano, A. and Spagnolo, P. and Tenchini, R. and Tonelli, G. and Turini, N. and Venturi, A. and Verdini, P.G. and Barria, P. and Basile, C. and BIANCO, R. and Campana, M. and Cavallari, F. and Cunqueiro Mendez, L. and Dafinei, I. and Del Re, D. and Di Marco, E. and Diemoz, M. and Errico, F. and Failla, F. and Longo, E. and Meridiani, P. and Mijuskovic, J. and Nicolau, C.A. and Nuccetelli, M. and Organtini, G. and Pandolfi, F. and Paramatti, R. and Pettinacci, V. and Quaranta, C. and Rahatlou, S. and Rovelli, C. and Santanastasio, F. and Soffi, L. and Tramontano, R. and Amapane, N. and Arcidiacono, R. and Argiro, S. and Arneodo, M. and Bartosik, N. and Bellan, R. and Bellora, A. and Biino, C. and Cartiglia, N. and Coli, S. and Costa, M. and Covarelli, R. and Dattola, D. and Demaria, N. and Finco, L. and Grippo, M. and Kiani, B. and Legger, F. and Luongo, F. and Mariotti, C. and Maselli, S. and Mecca, A. and Migliore, E. and Monteno, M. and Mulargia, R. and Obertino, M.M. and Ortona, G. and Pacher, L. and Pastrone, N. and Pelliccioni, M. and Ruspa, M. and Siviero, F. and Sola, V. and Solano, A. and Tarricone, C. and Tornago, M. and Trocino, D. and Umoret, G. and Vagnerini, A. and Vlasov, E. and Belforte, S. and Candelise, V. and Casarsa, M. and Cossutti, F. and De Leo, K. and Della Ricca, G. and Dogra, S. and Huh, C. and Kim, B. and Kim, D.H. and Kim, J. and Lee, J. and Lee, S.W. and Moon, C.S. and Oh, Y.D. and Pak, S.I. and Ryu, M.S. and Sekmen, S. and Yang, Y.C. and Bak, G. and Gwak, P. and Kim, H. and Moon, D.H. and Asilar, E. and Kim, D. and Kim, T.J. and Merlin, J.A. and Park, J. and Choi, S. and Han, S. and Hong, B. and Lee, K. and Lee, K.S. and Park, J. and Park, S.K. and Yoo, J. and Goh, J. and Kim, H.S. and Kim, Y. and Lee, S. and Almond, J. and Bhyun, J.H. and Choi, J. and Jeon, S. and Jun, W. and Kim, J. and Kim, J.S. and Ko, S. and Kwon, H. and Lee, H. and Lee, J. and Lee, S. and Oh, B.H. and Oh, S.B. and Seo, H. and Yang, U.K. and Yoon, I. and Jang, W. and Kang, D.Y. and Kang, Y. and Kim, S. and Ko, B. and Lee, J.S.H. and Lee, Y. and Park, I.C. and Roh, Y. and Watson, I.J. and Yang, S. and Ha, S. and Yoo, H.D. and Choi, M. and Kim, M.R. and Lee, H. and Lee, Y. and Yu, I. and Beyrouthy, T. and Maghrbi, Y. and Dreimanis, K. and Gaile, A. and Pikurs, G. and Potrebko, A. and Seidel, M. and Veckalns, V. and Strautnieks, N.R. and Ambrozas, M. and Juodagalvis, A. and Rinkevicius, A. and Tamulaitis, G. and Bin Norjoharuddeen, N. and Yusuff, I. and Zolkapli, Z. and Benitez, J.F. and Castaneda Hernandez, A. and Encinas Acosta, H.A. and Gallegos Maríñez, L.G. and León Coello, M. and Murillo Quijada, J.A. and Sehrawat, A. and Valencia Palomo, L. and Ayala, G. and Castilla-Valdez, H. and De La Cruz-Burelo, E. and Heredia-De La Cruz, I. and Lopez-Fernandez, R. and Mondragon Herrera, C.A. and Perez Navarro, D.A. and Sánchez Hernández, A. and Oropeza Barrera, C. and Ramírez García, M. and Bautista, I. and Pedraza, I. and Salazar Ibarguen, H.A. and Uribe Estrada, C. and Bubanja, I. and Raicevic, N. and Butler, P.H. and Ahmad, A. and Asghar, M.I. and Awais, A. and Awan, M.I.M. and Hoorani, H.R. and Khan, W.A. and Avati, V. and Grzanka, L. and Malawski, M. and Bialkowska, H. and Bluj, M. and Boimska, B. and Górski, M. and Kazana, M. and Szleper, M. and Zalewski, P. and Bunkowski, K. and Doroba, K. and Kalinowski, A. and Kierzkowski, K. and Konecki, M. and Krolikowski, J. and Oklinski, W. and Pozniak, K. and Zabolotny, W. and Araujo, M. and Bastos, D. and Silva, C.Beirão Da Cruz E. and Boletti, A. and Bozzo, M. and Da Molin, G. and Faccioli, P. and Gallinaro, M. and Hollar, J. and Leonardo, N. and Niknejad, T. and Pisano, M. and Rasteiro Da Silva, J. and Seixas, J. and Varela, J. and Wulff, J.W. and Adzic, P. and Milenovic, P. and Dordevic, M. and Milosevic, J. and Rekovic, V. and Aguilar-Benitez, M. and Alcaraz Maestre, J. and Barrio Luna, M. and Bedoya, Cristina F. and Cepeda, M. and Cerrada, M. and Colino, N. and Cuchillo Ortega, J. and De La Cruz, B. and De Lara Rodríguez, C.I. and Delgado Peris, A. and Fernández Del Val, D. and Fernández Ramos, J.P. and Flix, J. and Fouz, M.C. and Gonzalez Lopez, O. and Goy Lopez, S. and Hernandez, J.M. and Josa, M.I. and León Holgado, J. and Manzanilla, O. and Moran, D. and Morcillo Perez, C.M. and Navarro Tobar, Á. and Paz Herrera, R. and Perez Dengra, C. and Pérez-Calero Yzquierdo, A. and Puerta Pelayo, J. and Redondo, I. and Redondo Ferrero, D.D. and Romero, L. and Sánchez Navas, S. and Sastre, J. and Urda Gómez, L. and Vazquez Escobar, J. and Willmott, C. and de Trocóniz, J.F. and Alvarez Gonzalez, B. and Cuevas, J. and Fernandez Menendez, J. and Folgueras, S. and Gonzalez Caballero, I. and González Fernández, J.R. and Palencia Cortezon, E. and Ramón Álvarez, C. and Rodríguez Bouza, V. and Soto Rodríguez, A. and Trapote, A. and Vico Villalba, C. and Vischia, P. and Bhowmik, S. and Blanco Fernández, S. and Brochero Cifuentes, J.A. and Cabrillo, I.J. and Calderon, A. and Duarte Campderros, J. and Fernandez, M. and Fernandez Madrazo, C. and Gomez, G. and Lasaosa García, C. and Martinez Rivero, C. and Martinez Ruiz del Arbol, P. and Matorras, F. and Matorras Cuevas, P. and Navarrete Ramos, E. and Piedra Gomez, J. and Prieels, C. and Scodellaro, L. and Vila, I. and Vizan Garcia, J.M. and Jayananda, M.K. and Kailasapathy, B. and Sonnadara, D.U.J. and Wickramarathna, D.D.C. and Dharmaratna, W.G.D. and Liyanage, K. and Perera, N. and Wickramage, N. and Abbaneo, D. and Amendola, C. and Amoiridis, V. and Auffray, E. and Auzinger, G. and Baechler, J. and Barney, D. and Bermúdez Martínez, A. and Bianco, M. and Bilin, B. and Bin Anuar, A.A. and Bocci, A. and Brondolin, E. and Brummer, P. and Caillol, C. and Camporesi, T. and Cerminara, G. and Chernyavskaya, N. and Curé, B. and d'Enterria, D. and Dabrowski, A. and David, A. and De Roeck, A. and Defranchis, M.M. and Deile, M. and Deldicque, C. and Dobson, M. and Dvorak, A. and Fallavollita, F. and Forthomme, L. and Franzoni, G. and Funk, W. and Giani, S. and Gigi, D. and Gill, K. and Glege, F. and Gouskos, L. and Gutic, N. and Haranko, M. and Hegeman, J. and Innocente, V. and Izquierdo Moreno, G. and James, T. and Janot, P. and Kieseler, J. and Kishimoto Bisbe, C. and Kratochwil, N. and Laurila, S. and Lecoq, P. and Leutgeb, E. and Lourenço, C. and Maier, B. and Malgeri, L. and Mannelli, M. and Marini, A.C. and Meijers, F. and Mersi, S. and Meschi, E. and Milosevic, V. and Mommsen, R.K. and Moortgat, F. and Mulders, M. and Orfanelli, S. and Orsini, L. and Pantaleo, F. and Peron, K. and Peruzzi, M. and Petrilli, A. and Petrucciani, G. and Pfeiffer, A. and Pierini, M. and Piparo, D. and Poupakis, A. and Qu, H. and Rabady, D. and Racz, A. and Reales Gutiérrez, G. and Rovere, M. and Sakulin, H. and Scarfi, S. and Schwick, C. and Selvaggi, M. and Sharma, A. and Shchelina, K. and Silva, P. and Sphicas, P. and Stahl Leiton, A.G. and Steen, A. and Summers, S. and Treille, D. and Tropea, P. and Tsirou, A. and Vázquez, C. and Walter, D. and Wanczyk, J. and Wozniak, K.A. and Zehetner, P. and Zejdl, P. and Zeuner, W.D. and Bevilacqua, T. and Caminada, L. and Ebrahimi, A. and Erdmann, W. and Horisberger, R. and Ingram, Q. and Kaestli, H.C. and Kotlinski, D. and Lange, C. and Meier, B. and Missiroli, M. and Noehte, L. and Rohe, T. and Streuli, S. and Aarrestad, T.K. and Androsov, K. and Backhaus, M. and Bonomelli, G. and Burkhalter, S. and Calandri, A. and Cazzaniga, C. and Datta, K. and De Cosa, A. and Dissertori, G. and Dittmar, M. and Donegà, M. and Eble, F. and Gadek, T. and Galli, M. and Gedia, K. and Glessgen, F. and Grab, C. and Härringer, N. and Harte, T.G. and Hits, D. and Lustermann, W. and Lyon, A.-M. and Manzoni, R.A. and Marchegiani, M. and Marchese, L. and Martin Perez, C. and Mascellani, A. and Nessi-Tedaldi, F. and Pauss, F. and Perovic, V. and Pigazzini, S. and Ratti, M.G. and Reissel, C. and Reitenspiess, T. and Ristic, B. and Riti, F. and Ruini, D. and Seidita, R. and Stachon, K. and Steggemann, J. and Valsecchi, D. and Wallny, R. and Amsler, C. and Bärtschi, P. and Boesiger, K. and Botta, C. and Brzhechko, D. and Canelli, M.F. and Cormier, K. and De Wit, A. and Del Burgo, R. and Gienal, M. and Heikkilä, J.K. and Hernandez Garland, D. and Huwiler, M. and Jin, W. and Jofrehei, A. and Kilminster, B. and Leontsinis, S. and Liechti, S.P. and Macchiolo, A. and Maier, R. and Meiring, P. and Mikuni, V.M. and Molinatti, U. and Neuenschwander, B. and Neutelings, I. and Rauco, G. and Reimers, A. and Robmann, P. and Salerno, D. and Sanchez Cruz, S. and Schweiger, K. and Senger, M. and Takahashi, Y. and Wiederkehr, S.A. and Wolf, D. and Adloff, C. and Kuo, C.M. and Lin, W. and Rout, P.K. and Tiwari, P.C. and Yu, S.S. and Ceard, L. and Chao, Y. and Chen, K.F. and Chen, P.s. and Chen, Z.g. and Hou, W.-S. and Hsu, T.h. and Kao, Y.w. and Khurana, R. and Kole, G. and Li, Y.y. and Lu, R.-S. and Paganis, E. and Psallidas, A. and Su, X.f. and Thomas-Wilsker, J. and Wu, H.y. and Yazgan, E. and Asawatangtrakuldee, C. and Srimanobhas, N. and Wachirapusitanand, V. and Agyel, D. and Boran, F. and Demiroglu, Z.S. and Dolek, F. and Dumanoglu, I. and Eskut, E. and Guler, Y. and Gurpinar Guler, E. and Isik, C. and Kara, O. and Kayis Topaksu, A. and Kiminsu, U. and Onengut, G. and Ozdemir, K. and Polatoz, A. and Tali, B. and Tok, U.G. and Turkcapar, S. and Uslan, E. and Zorbakir, I.S. and Ocalan, K. and Yalvac, M. and Akgun, B. and Atakisi, I.O. and Gülmez, E. and Kaya, M. and Kaya, O. and Tekten, S. and Yetkin, E.A. and Cakir, A. and Cankocak, K. and Komurcu, Y. and Sen, S. and Aydilek, O. and Cerci, S. and Epshteyn, V. and Hacisahinoglu, B. and Hos, I. and Isildak, B. and Kaynak, B. and Ozkorucuklu, S. and Sert, H. and Simsek, C. and Sunar Cerci, D. and Zorbilmez, C. and Yetkin, T. and Boyaryntsev, A. and Grynyov, B. and Levchuk, L. and Anthony, D. and Brooke, J.J. and Bundock, A. and Bury, F. and Clement, E. and Cussans, D. and Flacher, H. and Glowacki, M. and Goldstein, J. and Heath, H.F. and Kreczko, L. and Krikler, B. and Paramesvaran, S. and Seif El Nasr-Storey, S. and Smith, V.J. and Stylianou, N. and Walkingshaw Pass, K. and White, R. and Ball, A.H. and Bell, K.W. and Belyaev, A. and Brew, C. and Brown, R.M. and Cockerill, D.J.A. and Cooke, C. and Ellis, K.V. and Harder, K. and Harper, S. and Holmberg, M.-L. and Jain, Sh. and Linacre, J. and Manolopoulos, K. and Newbold, D.M. and Olaiya, E. and Petyt, D. and Reis, T. and Salvi, G. and Schuh, T. and Shepherd-Themistocleous, C.H. and Tomalin, I.R. and Williams, T. and Bainbridge, R. and Bloch, P. and Brown, C.E. and Buchmuller, O. and Cacchio, V. and Carrillo Montoya, C.A. and Chahal, G.S. and Colling, D. and Dancu, J.S. and Dauncey, P. and Davies, G. and Davies, J. and Della Negra, M. and Fayer, S. and Fedi, G. and Hall, G. and Hassanshahi, M.H. and Howard, A. and Iles, G. and Knight, M. and Langford, J. and Lyons, L. and Magnan, A.-M. and Malik, S. and Martelli, A. and Mieskolainen, M. and Nash, J. and Pesaresi, M. and Radburn-Smith, B.C. and Richards, A. and Rose, A. and Seez, C. and Shukla, R. and Tapper, A. and Uchida, K. and Uttley, G.P. and Vage, L.H. and Virdee, T. and Vojinovic, M. and Wardle, N. and Winterbottom, D. and Coldham, K. and Cole, J.E. and Khan, A. and Kyberd, P. and Reid, I.D. and Abdullin, S. and Brinkerhoff, A. and Caraway, B. and Dittmann, J. and Hatakeyama, K. and Hiltbrand, J. and Kanuganti, A.R. and McMaster, B. and Saunders, M. and Sawant, S. and Sutantawibul, C. and Toms, M. and Wilson, J. and Bartek, R. and Dominguez, A. and Huerta Escamilla, C. and Simsek, A.E. and Uniyal, R. and Vargas Hernandez, A.M. and Chudasama, R. and Cooper, S.I. and Gleyzer, S.V. and Perez, C.U. and Rumerio, P. and Usai, E. and West, C. and Akpinar, A. and Albert, A. and Arcaro, D. and Cosby, C. and Demiragli, Z. and Erice, C. and Fontanesi, E. and Gastler, D. and Rohlf, J. and Salyer, K. and Sperka, D. and Spitzbart, D. and Suarez, I. and Tsatsos, A. and Yuan, S. and Benelli, G. and Coubez, X. and Cutts, D. and Hadley, M. and Heintz, U. and Hogan, J.M. and Kwon, T. and Landsberg, G. and Lau, K.T. and Li, D. and Luo, J. and Mondal, S. and Narain, M. and Pervan, N. and Sagir, S. and Simpson, F. and Wong, W.Y. and Yan, X. and Yu, D. and Zhang, W. and Abbott, S. and Bonilla, J. and Brainerd, C. and Breedon, R. and Calderon De La Barca Sanchez, M. and Chertok, M. and Citron, M. and Conway, J. and Cox, P.T. and Erbacher, R. and Haza, G. and Jensen, F. and Kukral, O. and Mocellin, G. and Mulhearn, M. and Pellett, D. and Regnery, B. and Wei, W. and Yao, Y. and Zhang, F. and Bachtis, M. and Cousins, R. and Datta, A. and Hauser, J. and Ignatenko, M. and Iqbal, M.A. and Lam, T. and Manca, E. and Nash, W.A. and Saltzberg, D. and Stone, B. and Valuev, V. and Clare, R. and Gordon, M. and Hanson, G. and Si, W. and Wimpenny, S. and Branson, J.G. and Cittolin, S. and Cooperstein, S. and Diaz, D. and Duarte, J. and Gerosa, R. and Giannini, L. and Guiang, J. and Kansal, R. and Krutelyov, V. and Lee, R. and Letts, J. and Masciovecchio, M. and Mokhtar, F. and Morovic, S. and Petrucci, A. and Pieri, M. and Quinnan, M. and Sathia Narayanan, B.V. and Sharma, V. and Tadel, M. and Vourliotis, E. and Würthwein, F. and Xiang, Y. and Yagil, A. and Brennan, L. and Campagnari, C. and Collura, G. and Dorsett, A. and Incandela, J. and Kilpatrick, M. and Kim, J. and Li, A.J. and Masterson, P. and Mei, H. and Oshiro, M. and Richman, J. and Sarica, U. and Schmitz, R. and Setti, F. and Sheplock, J. and Stuart, D. and Wang, S. and Balcas, J. and Bornheim, A. and Cerri, O. and Latorre, A. and Lawhorn, J.M. and Mao, J. and Newman, H.B. and Nguyen, T.Q. and Spiropulu, M. and Vlimant, J.R. and Wang, C. and Xie, S. and Zhu, R.Y. and Alison, J. and An, S. and Andrews, M.B. and Bryant, P. and Dutta, V. and Ferguson, T. and Harilal, A. and Liu, C. and Mudholkar, T. and Murthy, S. and Paulini, M. and Roberts, A. and Sanchez, A. and Terrill, W. and Cumalat, J.P. and Ford, W.T. and Hassani, A. and Karathanasis, G. and MacDonald, E. and Manganelli, N. and Marini, F. and Perloff, A. and Savard, C. and Schonbeck, N. and Stenson, K. and Ulmer, K.A. and Wagner, S.R. and Zipper, N. and Alexander, J. and Bright-Thonney, S. and Chen, X. and Cranshaw, D.J. and Fan, J. and Fan, X. and Gadkari, D. and Hogan, S. and Monroy, J. and Patterson, J.R. and Reichert, J. and Reid, M. and Ryd, A. and Thom, J. and Wittich, P. and Zou, R. and Adelman-McCarthy, J. and Albrow, M. and Alyari, M. and Amram, O. and Apollinari, G. and Apresyan, A. and Bauerdick, L.A.T. and Berry, D. and Berryhill, J. and Bhat, P.C. and Burkett, K. and Butler, J.N. and Canepa, A. and Cerati, G.B. and Cheung, H.W.K. and Chlebana, F. and Cummings, G. and Dagenhart, W. and Dickinson, J. and Dutta, I. and Elvira, V.D. and Feng, Y. and Freeman, J. and Gandrakota, A. and Gartung, P. and Gecse, Z. and Gray, L. and Green, D. and Grünendahl, S. and Guerrero, D. and Gutsche, O. and Harris, R.M. and Heller, R. and Herwig, T.C. and Hirschauer, J. and Horyn, L. and Hufnagel, D. and Jayatilaka, B. and Jindariani, S. and Johnson, M. and Jones, C.D. and Joshi, U. and Klijnsma, T. and Klima, B. and Kortelainen, M.J. and Kwok, K.H.M. and Lammel, S. and Lincoln, D. and Lipton, R. and Liu, T. and Madrid, C. and Maeshima, K. and Mantilla, C. and Mason, D. and McBride, P. and Merkel, P. and Mrenna, S. and Nahn, S. and Ngadiuba, J. and Noonan, D. and Papadimitriou, V. and Pastika, N. and Pedro, K. and Pena, C. and Ravera, F. and Reinsvold Hall, A. and Ristori, L. and Sexton-Kennedy, E. and Smith, N. and Soha, A. and Spiegel, L. and Stoynev, S. and Taylor, L. and Tkaczyk, S. and Tran, N.V. and Uplegger, L. and Vaandering, E.W. and Zoi, I. and Aruta, C. and Avery, P. and Bourilkov, D. and Cadamuro, L. and Chang, P. and Cherepanov, V. and Field, R.D. and Koenig, E. and Kolosova, M. and Konigsberg, J. and Korytov, A. and Lo, K.H. and Matchev, K. and Menendez, N. and Mitselmakher, G. and Muthirakalayil Madhu, A. and Rawal, N. and Rosenzweig, D. and Rosenzweig, S. and Shi, K. and Wang, J. and Adams, T. and Al Kadhim, A. and Askew, A. and Bower, N. and Habibullah, R. and Hagopian, V. and Hashmi, R. and Kim, R.S. and Kim, S. and Kolberg, T. and Martinez, G. and Prosper, H. and Prova, P.R. and Viazlo, O. and Wulansatiti, M. and Yohay, R. and Zhang, J. and Alsufyani, B. and Baarmand, M.M. and Butalla, S. and Elkafrawy, T. and Hohlmann, M. and Kumar Verma, R. and Rahmani, M. and Yumiceva, F. and Adams, M.R. and Bennett, C. and Cavanaugh, R. and Dittmer, S. and Escobar Franco, R. and Evdokimov, A. and Evdokimov, O. and Gerber, C.E. and Hofman, D.J. and Lee, J.h. and Lemos, D.S. and Merrit, A.H. and Mills, C. and Nanda, S. and Oh, G. and Ozek, B. and Pilipovic, D. and Roy, T. and Rudrabhatla, S. and Tonjes, M.B. and Varelas, N. and Wang, X. and Ye, Z. and Yoo, J. and Alhusseini, M. and Bilki, B. and Blend, D. and Debbins, P. and Dilsiz, K. and Emediato, L. and Karaman, G. and Köseyan, O.K. and Merlo, J.-P. and Mestvirishvili, A. and Miller, M.J. and Nachtman, J. and Neogi, O. and Ogul, H. and Onel, Y. and Penzo, A. and Schmidt, I. and Snyder, C. and Southwick, D. and Tiras, E. and Wetzel, J. and Blumenfeld, B. and Corcodilos, L. and Davis, J. and Gritsan, A.V. and Kang, L. and Kyriacou, S. and Maksimovic, P. and Roguljic, M. and Roskes, J. and Sekhar, S. and Swartz, M. and Vámi, T.Á. and Abreu, A. and Alcerro Alcerro, L.F. and Anguiano, J. and Baringer, P. and Bean, A. and Flowers, Z. and Grove, D. and King, J. and Krintiras, G. and Lazarovits, M. and Le Mahieu, C. and Lindsey, C. and Marquez, J. and Minafra, N. and Murray, M. and Nickel, M. and Pitt, M. and Popescu, S. and Rogan, C. and Royon, C. and Salvatico, R. and Sanders, S. and Smith, C. and Wang, Q. and Wilson, G. and Allmond, B. and Ivanov, A. and Kaadze, K. and Kalogeropoulos, A. and Kim, D. and Maravin, Y. and Nam, K. and Natoli, J. and Roy, D. and Sorrentino, G. and Rebassoo, F. and Wright, D. and Adams, E. and Baden, A. and Baron, O. and Belloni, A. and Bethani, A. and Chen, Y.m. and Eno, S.C. and Hadley, N.J. and Jabeen, S. and Kellogg, R.G. and Koeth, T. and Lai, Y. and Lascio, S. and Mignerey, A.C. and Nabili, S. and Palmer, C. and Papageorgakis, C. and Paranjpe, M.M. and Wang, L. and Wong, K. and Bendavid, J. and Busza, W. and Cali, I.A. and Chen, Y. and D'Alfonso, M. and Darlea, G.L. and Eysermans, J. and Freer, C. and Gomez-Ceballos, G. and Goncharov, M. and Harris, P. and Hoang, D. and Kovalskyi, D. and Krupa, J. and Lavezzo, L. and Lee, Y.-J. and Long, K. and Mironov, C. and Paus, C. and Rankin, D. and Roland, C. and Roland, G. and Rothman, S. and Shi, Z. and Stephans, G.S.F. and Wang, J. and Wang, Z. and Wyslouch, B. and Yang, T.J. and Crossman, B. and Frahm, E. and Joshi, B.M. and Kapsiak, C. and Krohn, M. and Mahon, D. and Mans, J. and Revering, M. and Rusack, R. and Saradhy, R. and Schroeder, N. and Strobbe, N. and Wadud, M.A. and Cremaldi, L.M. and Bloom, K. and Bryson, M. and Claes, D.R. and Fangmeier, C. and Golf, F. and Joo, C. and Kravchenko, I. and Reed, I. and Siado, J.E. and Snow, G.R. and Tabb, W. and Wightman, A. and Yan, F. and Zecchinelli, A.G. and Agarwal, G. and Bandyopadhyay, H. and Hay, L. and Iashvili, I. and Kharchilava, A. and McLean, C. and Morris, M. and Nguyen, D. and Pekkanen, J. and Rappoccio, S. and Rejeb Sfar, H. and Williams, A. and Alverson, G. and Barberis, E. and Dervan, J. and Haddad, Y. and Han, Y. and Krishna, A. and Li, J. and Lu, M. and Madigan, G. and Marzocchi, B. and Morse, D.M. and Nguyen, V. and Orimoto, T. and Parker, A. and Skinnari, L. and Tishelman-Charny, A. and Wang, B. and Wood, D. and Bhattacharya, S. and Bueghly, J. and Chen, Z. and Hahn, K.A. and Liu, Y. and Miao, Y. and Monk, D.G. and Schmitt, M.H. and Taliercio, A. and Velasco, M. and Band, R. and Bucci, R. and Castells, S. and Cremonesi, M. and Das, A. and Goldouzian, R. and Hildreth, M. and Ho, K.W. and Hurtado Anampa, K. and Jessop, C. and Lannon, K. and Lawrence, J. and Loukas, N. and Lutton, L. and Mariano, J. and Marinelli, N. and Mcalister, I. and McCauley, T. and Mcgrady, C. and Mohrman, K. and Moore, C. and Musienko, Y. and Nelson, H. and Osherson, M. and Ruchti, R. and Townsend, A. and Wayne, M. and Yockey, H. and Zarucki, M. and Zygala, L. and Basnet, A. and Bylsma, B. and Carrigan, M. and Durkin, L.S. and Hill, C. and Joyce, M. and Lesauvage, A. and Nunez Ornelas, M. and Wei, K. and Winer, B.L. and Yates, B.R. and Addesa, F.M. and Bouchamaoui, H. and Das, P. and Dezoort, G. and Elmer, P. and Frankenthal, A. and Greenberg, B. and Haubrich, N. and Higginbotham, S. and Kopp, G. and Kwan, S. and Lange, D. and Loeliger, A. and Marlow, D. and Ojalvo, I. and Olsen, J. and Stickland, D. and Tully, C. and Malik, S. and Bakshi, A.S. and Barnes, V.E. and Chandra, S. and Chawla, R. and Das, S. and Gu, A. and Gutay, L. and Jones, M. and Jung, A.W. and Kondratyev, D. and Koshy, A.M. and Liu, M. and Negro, G. and Neumeister, N. and Paspalaki, G. and Piperov, S. and Purohit, A. and Schulte, J.F. and Stojanovic, M. and Thieman, J. and Virdi, A.K. and Wang, F. and Wildridge, A. and Xie, W. and Dolen, J. and Parashar, N. and Pathak, A. and Acosta, D. and Banicz, K. and Baty, A. and Behrens, U. and Carnahan, T. and Dildick, S. and Ecklund, K.M. and Fernández Manteca, P.J. and Freed, S. and Gardner, P. and Geurts, F.J.M. and Kelling, P. and Krawczyk, R. and Kumar, A. and Li, W. and Liu, J.H. and Matveev, M. and Miguel Colin, O. and Nussbaum, T. and Padley, B.P. and Redjimi, R. and Rotter, J. and Yigitbasi, E. and Zhang, Y. and Bodek, A. and de Barbaro, P. and Demina, R. and Dulemba, J.L. and Fallon, C. and Garcia-Bellido, A. and Hindrichs, O. and Khukhunaishvili, A. and Parygin, P. and Popova, E. and Taus, R. and Van Onsem, G.P. and Goulianos, K. and Chiarito, B. and Chou, J.P. and Gershtein, Y. and Halkiadakis, E. and Hart, A. and Heindl, M. and Jaroslawski, D. and Karacheban, O. and Laflotte, I. and Lath, A. and Montalvo, R. and Nash, K. and Routray, H. and Salur, S. and Schnetzer, S. and Somalwar, S. and Stone, R. and Thayil, S.A. and Thomas, S. and Vora, J. and Wang, H. and Acharya, H. and Ally, D. and Delannoy, A.G. and Fiorendi, S. and Holmes, T. and Karunarathna, N. and Lee, L. and Nibigira, E. and Spanier, S. and Aebi, D. and Ahmad, M. and Akhter, T. and Bouhali, O. and Dalchenko, M. and Eusebi, R. and Gilmore, J. and Huang, T. and Kamon, T. and Kim, H. and Luo, S. and Malhotra, S. and Mueller, R. and Overton, D. and Rathjens, D. and Safonov, A. and Akchurin, N. and Damgov, J. and Hegde, V. and Hussain, A. and Kazhykarim, Y. and Lamichhane, K. and Lee, S.W. and Mankel, A. and Mengke, T. and Muthumuni, S. and Peltola, T. and Volobouev, I. and Whitbeck, A. and Appelt, E. and Greene, S. and Gurrola, A. and Johns, W. and Kunnawalkam Elayavalli, R. and Melo, A. and Romeo, F. and Sheldon, P. and Tuo, S. and Velkovska, J. and Viinikainen, J. and Cardwell, B. and Cox, B. and Goadhouse, S. and Hakala, J. and Hirosky, R. and Ledovskoy, A. and Li, A. and Neu, C. and Perez Lara, C.E. and Karchin, P.E. and Aravind, A. and Banerjee, S. and Black, K. and Bose, T. and Dasu, S. and De Bruyn, I. and Everaerts, P. and Galloni, C. and He, H. and Herndon, M. and Herve, A. and Koraka, C.K. and Lanaro, A. and Loveless, R. and Madhusudanan Sreekala, J. and Mallampalli, A. and Mohammadi, A. and Mondal, S. and Parida, G. and Pinna, D. and Savin, A. and Shang, V. and Sharma, V. and Smith, W.H. and Teague, D. and Tsoi, H.F. and Vetens, W. and Warden, A. and Afanasiev, S. and Andreev, V. and Andreev, Yu. and Aushev, T. and Azarkin, M. and Babaev, A. and Belyaev, A. and Blinov, V. and Boos, E. and Borshch, V. and Budkouski, D. and Chadeeva, M. and Chekhovsky, V. and Dermenev, A. and Dimova, T. and Druzhkin, D. and Dubinin, M. and Dudko, L. and Ershov, A. and Gavrilov, G. and Gavrilov, V. and Gninenko, S. and Golovtcov, V. and Golubev, N. and Golutvin, I. and Gorbunov, I. and Gribushin, A. and Ivanov, Y. and Kachanov, V. and Kardapoltsev, L. and Karjavine, V. and Karneyeu, A. and Khein, L. and Kim, V. and Kirakosyan, M. and Kirpichnikov, D. and Kirsanov, M. and Klyukhin, V. and Kodolova, O. and Konstantinov, D. and Korenkov, V. and Kozyrev, A. and Krasnikov, N. and Lanev, A. and Levchenko, P. and Litomin, A. and Lukina, O. and Lychkovskaya, N. and Malakhov, A. and Matveev, V. and Murzin, V. and Nikitenko, A. and Obraztsov, S. and Oreshkin, V. and Oskin, A. and Palichik, V. and Perelygin, V. and Petrushanko, S. and Polikarpov, S. and Popov, V. and Radchenko, O. and Rusinov, V. and Savina, M. and Savrin, V. and Selivanova, D. and Shalaev, V. and Shmatov, S. and Shulha, S. and Skovpen, Y. and Slabospitskii, S. and Smirnov, V. and Sosnov, D. and Sulimov, V. and Tcherniaev, E. and Terkulov, A. and Teryaev, O. and Tlisova, I. and Toropin, A. and Uvarov, L. and Uzunian, A. and Vorobyev, A. and Voytishin, N. and Yuldashev, B.S. and Zarubin, A. and Zhizhin, I. and Zhokin, A. and The CMS collaboration},
+title = {Development of the CMS detector for the CERN LHC Run 3},
+journal = {Journal of Instrumentation},
+abstract = {Since the initial data taking of the CERN LHC, the CMS experiment has undergone substantial upgrades and improvements. This paper discusses the CMS detector as it is configured for the third data-taking period of the CERN LHC, Run 3, which started in 2022. The entire silicon pixel tracking detector was replaced. A new powering system for the superconducting solenoid was installed. The electronics of the hadron calorimeter was upgraded. All the muon electronic systems were upgraded, and new muon detector stations were added, including a gas electron multiplier detector. The precision proton spectrometer was upgraded. The dedicated luminosity detectors and the beam loss monitor were refurbished. Substantial improvements to the trigger, data acquisition, software, and computing systems were also implemented, including a new hybrid CPU/GPU farm for the high-level trigger.}
+}
+
 @article{CMS-DP-2022-050,
   collaboration = {CMS},
   title         = {{Transformer models for heavy flavor jet identification}},
   year          = {2022},
   url           = {https://cds.cern.ch/record/2839920}
+}
+
+@article{CMS-DP-2023-079,
+      collaboration = "CMS",
+      title         = "{Anomaly Detection in the CMS Global Trigger Test Crate
+                       for Run 3}",
+      year          = "2023",
+      url           = "https://cds.cern.ch/record/2876546",
+}
+
+@article{CMS-DP-2024-086,
+      collaboration = "CMS",
+      title         = "{Quantifying the computational speedup with madgraph4gpu
+                       for CMS worflow}",
+      year          = "2024",
+      url           = "https://cds.cern.ch/record/2914584",
+}
+
+@article{CMS:2024jdl,
+    author = "Hayrapetyan, Aram and others",
+    collaboration = "CMS",
+    title = "{Reweighting simulated events using machine-learning techniques in the CMS experiment}",
+    eprint = "2411.03023",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "CMS-MLG-24-001, CERN-EP-2024-269",
+    month = "11",
+    year = "2024"
 }
 
 @misc{cmswmass,
@@ -167,6 +434,38 @@
   archiveprefix = {arXiv},
   primaryclass  = {hep-ex},
   url           = {https://arxiv.org/abs/2412.13872}
+}
+
+@article{CMS:2024lrd,
+    author = "Chekhovsky, Vladimir and others",
+    collaboration = "CMS",
+    title = "{High-precision measurement of the W boson mass with the CMS experiment at the LHC}",
+    eprint = "2412.13872",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "CMS-SMP-23-002, CERN-EP-2024-308",
+    month = "12",
+    year = "2024"
+}
+
+@misc{CMS:enriching_phys_programs,
+      title={Enriching the physics program of the CMS experiment via data scouting and data parking}, 
+      author={CMS Collaboration},
+      year={2024},
+      eprint={2403.16134},
+      archivePrefix={arXiv},
+      primaryClass={hep-ex},
+      url={https://arxiv.org/abs/2403.16134}, 
+}
+
+@article{Concas:2024cyu,
+    author = "Concas, Matteo",
+    title = "{A vendor-unlocked ITS GPU reconstruction in ALICE}",
+    doi = "10.1051/epjconf/202429502002",
+    journal = "EPJ Web Conf.",
+    volume = "295",
+    pages = "02002",
+    year = "2024"
 }
 
 @article{Corcella:2000bw,
@@ -183,6 +482,11 @@
   volume        = {01},
   pages         = {010},
   year          = {2001}
+}
+
+@online{CODAS-HEP,
+  title = {Computational and Data Science for High Energy Physics},
+  url = {https://codas-hep.org}
 }
 
 @article{Denner:2000bj,
@@ -219,6 +523,33 @@
   title  = {ECFA Higgs/Electroweak/Top Factory Study},
   year   = 2025
 }
+@techreport{European:2720131,
+      author        = "The European Strategy Group",
+      title         = "{Deliberation document on the 2020 Update of the European
+                       Strategy for Particle Physics}",
+      reportNumber  = "CERN-ESU-014",
+      address       = "Geneva",
+      year          = "2020",
+      url           = "https://cds.cern.ch/record/2720131",
+      doi           = "10.17181/ESU2020Deliberation",
+}
+
+@software{fastml_team_hls4ml,
+  author       = {FastML Team},
+  title        = {hls4ml},
+  month        = dec,
+  year         = 2024,
+  publisher    = {Zenodo},
+  version      = {v1.0.0},
+  doi          = {10.5281/zenodo.14344847},
+  url          = {https://doi.org/10.5281/zenodo.14344847},
+  swhid        = {swh:1:dir:89b236b850e53b07b2b4d192bda386950ed2eaea;
+                   origin=https://doi.org/10.5281/zenodo.1201549;
+                   visit=swh:1:snp:33b7cc998589768e0f28700c19e1e2be01272c24;
+                   anchor=swh:1:rel:873c2d2daca34b87c9ce249f5594738be8fd2861;path=/
+                  },
+}
+
 @software{fastml_hls4ml,
   author    = {{FastML Team}},
   title     = {fastmachinelearning/hls4ml},
@@ -228,6 +559,7 @@
   doi       = {10.5281/zenodo.1201549},
   url       = {https://github.com/fastmachinelearning/hls4ml}
 }
+
 @techreport{fatras,
   author        = {Hamilton, S and Kneringer, E and Lukas, W and Ritsch, E
                    and Salzburger, A and Sliwa, K and Todorova, S and Wetter,
@@ -240,6 +572,26 @@
   year          = {2011},
   url           = {https://cds.cern.ch/record/1341541}
 }
+
+@online{FIRST-HEP,
+  title = {Framework for Integrated Research Software Training in High Energy Physics},
+  url = {https://first-hep.org}
+}
+
+@article{Frederix:2020trv,
+    author = "Frederix, R. and Frixione, S. and Prestel, S. and Torrielli, P.",
+    title = "{On the reduction of negative weights in MC@NLO-type matching procedures}",
+    eprint = "2002.12716",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "LU-TP 20-09, MCNET-20-08",
+    doi = "10.1007/JHEP07(2020)238",
+    journal = "JHEP",
+    volume = "07",
+    pages = "238",
+    year = "2020"
+}
+
 @article{Frixione:2019lga,
   author        = {Frixione, Stefano},
   title         = {{Initial conditions for electron and photon structure and
@@ -253,6 +605,7 @@
   pages         = {158},
   year          = {2019}
 }
+
 @inproceedings{Frixione:2022ofv,
   author        = {Frixione, S. and others},
   title         = {{Initial state QED radiation aspects for future
@@ -271,6 +624,23 @@
   url   = {https://indico.cern.ch/event/1475445/contributions/6235431/attachments/2972929/5232615/Geant4InputToHSFDetSim.pdf}
 }
 
+@online{garfield++,
+  title = {Garfield++ toolkit},
+  url = {https://garfieldpp.web.cern.ch/garfieldpp/},
+}
+
+@article{GEANT4:2002zbu,
+    author = "Agostinelli, S. and others",
+    collaboration = "GEANT4",
+    title = "{GEANT4 - A Simulation Toolkit}",
+    reportNumber = "SLAC-PUB-9350, FERMILAB-PUB-03-339, CERN-IT-2002-003",
+    doi = "10.1016/S0168-9002(03)01368-8",
+    journal = "Nucl. Instrum. Meth. A",
+    volume = "506",
+    pages = "250--303",
+    year = "2003"
+
+}
 @article{Ganis2022,
   author  = {Ganis, Gerardo and Helsens, Cl{\'e}ment and V{\"o}lkl, Valentin},
   title   = {Key4hep, a framework for future HEP experiments and its use in FCC},
@@ -285,6 +655,17 @@
   doi     = {10.1140/epjp/s13360-021-02213-1},
   url     = {https://doi.org/10.1140/epjp/s13360-021-02213-1}
 }
+
+@misc{gardiner2024nuhepmc,
+      title={NuHepMC: A standardized event record format for neutrino event generators},
+      author={S. Gardiner and J. Isaacson and L. Pickering},
+      year={2024},
+      eprint={2310.13211},
+      archivePrefix={arXiv},
+      primaryClass={hep-ph},
+      url={https://arxiv.org/abs/2310.13211},
+}
+
 @article{Hageboeck:2020dyv,
   author        = {Hageboeck, Stephan},
   title         = {{What the new RooFit can do for your analysis}},
@@ -298,12 +679,35 @@
   year          = {2021}
 }
 
+@article{Hageboeck:2023blb,
+    author = "Hageboeck, Stephan and Childers, Taylor and Hopkins, Walter and Mattelaer, Olivier and Nichols, Nathan and Roiser, Stefan and Teig, J\o{}rgen and Valassi, Andrea and Vuosalo, Carl and Wettersten, Zenny",
+    title = "{Madgraph5\_aMC@NLO on GPUs and vector CPUs Experience with the first alpha release}",
+    eprint = "2312.02898",
+    archivePrefix = "arXiv",
+    primaryClass = "physics.comp-ph",
+    doi = "10.1051/epjconf/202429511013",
+    journal = "EPJ Web Conf.",
+    volume = "295",
+    pages = "11013",
+    year = "2024"
+}
+
+@article{Held:2022RC,
+  author = "Held, Alexander  and  Shadura, Oksana",
+  title = "{The IRIS-HEP Analysis Grand Challenge}",
+  doi = "10.22323/1.414.0235",
+  journal = "PoS",
+  year = 2022,
+  volume = "ICHEP2022",
+  pages = "235"
+}
 
 @misc{HS3github,
   title  = {HS3 - HEP Statistics Serialization Standard},
   author = {{The HS3 Committee}},
   url    = {https://github.com/hep-statistics-serialization-standard/hep-statistics-serialization-standard}
 }
+
 @article{hsfcwp,
   author  = {HEP Software Foundation},
   title   = {A Roadmap for HEP Software and Computing R\&D for the 2020s},
@@ -317,6 +721,17 @@
   doi     = {10.1007/s41781-018-0018-8},
   url     = {https://doi.org/10.1007/s41781-018-0018-8}
 }
+
+@misc{HSF-CWP-2017-02,
+      title={HEP Software Foundation Community White Paper Working Group - Training, Staffing and Careers}, 
+      author={HEP Software Foundation and : and Dario Berzano and Riccardo Maria Bianchi and Peter Elmer and Sergei V. Gleyzer John Harvey and Roger Jones and Michel Jouvin and Daniel S. Katz and Sudhir Malik and Dario Menasce and Mark Neubauer and Fernanda Psihas and Albert Puig Navarro and Graeme A. Stewart and Christopher Tunnell and Justin A. Vasel and Sean-Jiun Wang},
+      year={2019},
+      eprint={1807.02875},
+      archivePrefix={arXiv},
+      primaryClass={physics.ed-ph},
+      url={https://arxiv.org/abs/1807.02875}, 
+}
+
 @article{HSFPhysicsEventGeneratorWG:2020gxw,
   title     = {Challenges in Monte Carlo Event Generator Software for High-Luminosity LHC},
   volume    = {5},
@@ -329,6 +744,46 @@
   author    = {Valassi, Andrea and Yazgan, Efe and McFayden, Josh and Amoroso, Simone and Bendavid, Joshua and Buckley, Andy and Cacciari, Matteo and Childers, Taylor and Ciulli, Vitaliano and Frederix, Rikkert and Frixione, Stefano and Giuli, Francesco and Grohsjean, Alexander and Gütschow, Christian and Höche, Stefan and Hopkins, Walter and Ilten, Philip and Konstantinov, Dmitri and Krauss, Frank and Li, Qiang and Lönnblad, Leif and Maltoni, Fabio and Mangano, Michelangelo and Marshall, Zach and Mattelaer, Olivier and Fernandez Menendez, Javier and Mrenna, Stephen and Muralidharan, Servesh and Neumann, Tobias and Plätzer, Simon and Prestel, Stefan and Roiser, Stefan and Schönherr, Marek and Schulz, Holger and Schulz, Markus and Sexton-Kennedy, Elizabeth and Siegert, Frank and Siódmok, Andrzej and Stewart, Graeme A.},
   year      = {2021}
 }
+
+@online{HSFPyHEP,
+  title = {HSF PyHEP - Python in HEP},
+  url = {https://hepsoftwarefoundation.org/activities/pyhep.html}
+}
+
+@online{HSFTraining,
+  title = {HSF Training Activity},
+  url = {https://hepsoftwarefoundation.org/activities/training.html}
+}
+
+@online{HSFTrainingCenter,
+  title = {HSF Training Center},
+  url = {https://hsf-training.org/training-center/}
+}
+
+@article{Ilten:2022jfm,
+    author = "Ilten, Phil and Menzo, Tony and Youssef, Ahmed and Zupan, Jure",
+    title = "{Modeling hadronization using machine learning}",
+    eprint = "2203.04983",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    doi = "10.21468/SciPostPhys.14.3.027",
+    journal = "SciPost Phys.",
+    volume = "14",
+    number = "3",
+    pages = "027",
+    year = "2023"
+}
+
+@online{INFN:ESC_school,
+  title = {INFN Efficient Scientific Computing School},
+  url = {https://esc.infn.it}
+}
+
+@online{IRISHEP:Training,
+  title = {IRIS-HEP Training, Education and Outreach},
+  url = {https://iris-hep.org/ssc.html}
+}
+
 @article{Jadach:1991by,
   author       = {Jadach, S. and Richter-Was, E. and Ward, B. F. L. and Was,
                   Z.},
@@ -341,6 +796,7 @@
   pages        = {305-344},
   year         = {1992}
 }
+
 @article{Jadach:1999vf,
   author        = {Jadach, S. and Ward, B. F. L. and Was, Z.},
   title         = {{The Precision Monte Carlo event generator K K for two fermion
@@ -463,6 +919,56 @@
   year          = {2023}
 }
 
+@article{LHCb:RTDP,
+doi = {10.1088/1748-0221/14/04/P04006},
+url = {https://dx.doi.org/10.1088/1748-0221/14/04/P04006},
+year = {2019},
+month = apr,
+publisher = {},
+volume = {14},
+number = {04},
+pages = {P04006},
+author = {Aaij, R. and Benson, S. and Cian, M. De and Dziurda, A. and Fitzpatrick, C. and Govorkova, E. and Lupton, O. and Matev, R. and Neubert, S. and Pearce, A. and Schreiner, H. and Stahl, S. and Vesterinen, M.},
+title = {A comprehensive real-time analysis model at the LHCb experiment},
+journal = {Journal of Instrumentation},
+abstract = {An evolved real-time data processing strategy is proposed   for high-energy physics experiments, and its implementation at the   LHCb experiment is presented.  The reduced event model allows not   only the signal candidate firing the trigger to be persisted, as   previously available, but also an arbitrary set of other   reconstructed or raw objects from the event.  This allows for higher   trigger rates for a given output data bandwidth, when compared to   the traditional model of saving the full raw detector data for each   trigger, whilst accommodating inclusive triggers and preserving data   mining capabilities.  The gains in physics reach and savings in   computing resources already made possible by the model are   discussed, along with the prospects of employing it more widely for   Run 3 of the Large Hadron Collider.}
+}
+
+@article{Malik:2919564,
+      author        = "Malik, Sudhir and Lieret, Kilian and Elmer, Peter and
+                       Hernandez Villanueva, Michel and Roiser, Stefan",
+      title         = "{Train to Sustain}",
+      journal       = "EPJ Web Conf.",
+      volume        = "295",
+      pages         = "05023",
+      year          = "2024",
+      url           = "https://cds.cern.ch/record/2919564",
+      doi           = "10.1051/epjconf/202429505023",
+}
+
+@article{Malik2021Software,
+author = {Malik, Sudhir  and  Meehan, Samuel  and  Lieret, Kilian  and  Oan Evans, Meirin  and  Villanueva, Michel H.  and  Katz, Daniel S.  and  Stewart, Graeme A.  and  Elmer, Peter  and  Aziz, Sizar  and  Bellis, Matthew  and  Bianchi, Riccardo Maria  and  Bianco, Gianluca  and  Bonilla, Johan Sebastian  and  Burger, Angela  and  Burzynski, Jackson  and  Chamont, David  and  Feickert, Matthew  and  Gadow, Philipp  and  Gruber, Bernhard Manfred  and  Guest, Daniel  and  Hageboeck, Stephan  and  Heinrich, Lukas  and  Horzela, Maximilian M.  and  Huwiler, Marc  and  Lange, Clemens  and  Lehmann, Konstantin  and  Li, Ke  and  Majumder, Devdatta  and  Mamužić, Judita  and  Nelson, Kevin  and  Newhouse, Robin  and  Nibigira, Emery  and  Norberg, Scarlet  and  Pineda, Arturo Sánchez  and  Proffitt, Mason  and  Regnery, Brendan  and  Roepe, Amber  and  Roiser, Stefan  and  Schreiner, Henry  and  Shadura, Oksana  and  Stark, Giordon  and  Swatman, Stephen Nicholas  and  Thais, Savannah  and  Valassi, Andrea  and  Wunsch, Stefan  and  Yakobovitch, David  and  Yuan, Siqi},
+title = {Software Training in HEP},
+journal = {Computing and Software for Big Science},
+year  = {2021},
+volume  = {5},
+issue = {1},
+pages = {22-},
+doi  = {10.1007/s41781-021-00069-9},
+url  = {https://doi.org/10.1007/s41781-021-00069-9}
+}
+
+@article{Malik:chep2023_training_outreach,
+        author = {{Malik, Sudhir} and {Cordero, Danelix} and {Elmer, Peter} and {LaMee, Adam} and {Cecire, Ken}},
+        title = {Software Training Outreach In HEP},
+        DOI= "10.1051/epjconf/202429508018",
+        url= "https://doi.org/10.1051/epjconf/202429508018",
+        journal = {EPJ Web of Conf.},
+        year = 2024,
+        volume = 295,
+        pages = "08018",
+}
+
 @misc{maltoni2022tf07snowmassreporttheory,
   title         = {TF07 Snowmass Report: Theory of Collider Phenomena},
   author        = {Fabio Maltoni and Shufang Su and Jesse Thaler},
@@ -472,7 +978,6 @@
   primaryclass  = {hep-ph},
   url           = {https://arxiv.org/abs/2210.02591}
 }
-
 
 @inproceedings{MathesP3MA2017,
   author        = {{Matthes}, A. and {Widera}, R. and {Zenker}, E. and
@@ -489,6 +994,31 @@
   month         = jun,
   year          = {2017},
   url           = {https://arxiv.org/abs/1706.10086}
+}
+
+@InProceedings{matthew_rocklin-proc-scipy-2015,
+  author    = { {M}atthew {R}ocklin },
+  title     = { {D}ask: {P}arallel {C}omputation with {B}locked algorithms and {T}ask {S}cheduling },
+  booktitle = { {P}roceedings of the 14th {P}ython in {S}cience {C}onference },
+  pages     = { 126 - 132 },
+  year      = { 2015 },
+  editor    = { {K}athryn {H}uff and {J}ames {B}ergstra },
+  doi       = { 10.25080/Majora-7b98e3ed-013 }
+}
+
+@article{Moodie:2022flt,
+    author = "Moodie, Ryan",
+    title = "{Optimising hadronic collider simulations using amplitude neural networks}",
+    eprint = "2202.04506",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "IPPP/22/03",
+    doi = "10.1088/1742-6596/2438/1/012149",
+    journal = "J. Phys. Conf. Ser.",
+    volume = "2438",
+    number = "1",
+    pages = "012149",
+    year = "2023"
 }
 
 @online{neuralmodelHLT1LHCb,
@@ -523,6 +1053,36 @@
   volume  = 245,
   pages   = {11003}
 }
+
+@article{Pivarski_2020,
+   title={Awkward Arrays in Python, C++, and Numba},
+   volume={245},
+   ISSN={2100-014X},
+   url={http://dx.doi.org/10.1051/epjconf/202024505023},
+   DOI={10.1051/epjconf/202024505023},
+   journal={EPJ Web of Conferences},
+   publisher={EDP Sciences},
+   author={Pivarski, Jim and Elmer, Peter and Lange, David},
+   editor={Doglioni, C. and Kim, D. and Stewart, G.A. and Silvestris, L. and Jackson, P. and Kamleh, W.},
+   year={2020},
+   pages={05023}
+}
+
+@article{PhysRevD.105.096006,
+  title = {Novel event generator for the automated simulation of neutrino scattering},
+  author = {Isaacson, Joshua and H\"oche, Stefan and Lopez Gutierrez, Diego and Rocco, Noemi},
+  journal = {Phys. Rev. D},
+  volume = {105},
+  issue = {9},
+  pages = {096006},
+  numpages = {11},
+  year = {2022},
+  month = May,
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevD.105.096006},
+  url = {https://link.aps.org/doi/10.1103/PhysRevD.105.096006}
+}
+
 @article{Qu_2020,
   title     = {Jet tagging via particle clouds},
   volume    = {101},
@@ -536,6 +1096,7 @@
   year      = {2020},
   month     = mar
 }
+
 @misc{qu2024particletransformerjettagging,
   title         = {Particle Transformer for Jet Tagging},
   author        = {Huilin Qu and Congqiao Li and Sitian Qian},
@@ -560,6 +1121,28 @@
   pages     = {06028}
 }
 
+@article{ROOT:RDataFrame,
+        author = {{Piparo, Danilo} and {Canal, Philippe} and {Guiraud, Enrico} and {Pla, Xavier Valls} and {Ganis, Gerardo} and {Amadio, Guilherme} and {Naumann, Axel} and {Tejedor, Enric}},
+        title = {RDataFrame: Easy Parallel ROOT Analysis at 100 Threads},
+        DOI= "10.1051/epjconf/201921406029",
+        url= "https://doi.org/10.1051/epjconf/201921406029",
+        journal = {EPJ Web Conf.},
+        year = 2019,
+        volume = 214,
+        pages = "06029",
+}
+
+@article{ROOT:RDataFrame_prod_path,
+        author = {{Blomer, Jakob} and {Canal, Philippe} and {de Geus, Florine} and {Hahnfeld, Jonas} and {Naumann, Axel} and {Lopez-Gomez, Javier} and {Lazzari Miotto, Giovanna} and {Padulano, Vincenzo Eduardo}},
+        title = {ROOT’s RNTuple I/O Subsystem: The Path to Production},
+        DOI= "10.1051/epjconf/202429506020",
+        url= "https://doi.org/10.1051/epjconf/202429506020",
+        journal = {EPJ Web of Conf.},
+        year = 2024,
+        volume = 295,
+        pages = "06020",
+}
+
 @article{Schulte:1998au,
   author  = {Schulte, D.},
   editor  = {Ko, Kwok and Ryne, Robert D.},
@@ -569,6 +1152,23 @@
   pages   = {127-131},
   year    = {1998}
 }
+
+@article{Sherpa:2019gpd,
+    author = "Bothmann, Enrico and others",
+    collaboration = "Sherpa",
+    title = "{Event Generation with Sherpa 2.2}",
+    eprint = "1905.09127",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "FERMILAB-PUB-19-218-T, SLAC-PUB-17433, IPPP/19/42, MCNET-19-11",
+    doi = "10.21468/SciPostPhys.7.3.034",
+    journal = "SciPost Phys.",
+    volume = "7",
+    number = "3",
+    pages = "034",
+    year = "2019"
+}
+
 @article{Sherpa:2024mfk,
   author        = {Bothmann, Enrico
                    and Flower, Lois
@@ -603,6 +1203,7 @@
   reportnumber  = {IPPP/24/67, LTH-1385, FERMILAB-PUB-24-0748-T, ZU-TH
                    51/24, MCNET-24-17, CERN-TH-2024-171}
 }
+
 @article{Sjostrand:2006za,
   author        = {Sjostrand, Torbjorn and Mrenna, Stephen and Skands, Peter Z.},
   title         = {{PYTHIA 6.4 Physics and Manual}},
@@ -615,6 +1216,41 @@
   pages         = {026},
   year          = {2006}
 }
+
+@article{Smith_2020,
+   title={Coffea Columnar Object Framework For Effective Analysis},
+   volume={245},
+   ISSN={2100-014X},
+   url={http://dx.doi.org/10.1051/epjconf/202024506012},
+   DOI={10.1051/epjconf/202024506012},
+   journal={EPJ Web of Conferences},
+   publisher={EDP Sciences},
+   author={Smith, Nicholas and Gray, Lindsey and Cremonesi, Matteo and Jayatilaka, Bo and Gutsche, Oliver and Hall, Allison and Pedro, Kevin and Acosta, Maria and Melo, Andrew and Belforte, Stefano and Pivarski, Jim},
+   editor={Doglioni, C. and Kim, D. and Stewart, G.A. and Silvestris, L. and Jackson, P. and Kamleh, W.},
+   year={2020},
+   pages={06012}
+}
+
+@misc{Snowmass:2021_career_pipeline,
+      title={Summary Report of the Topical Group on Career Pipeline and Development (CommF2) Community Engagement Frontier Snowmass 2021}, 
+      author={Julie Hogan and Aneliya Karadzhinova-Ferrer and Sudhir Malik},
+      year={2022},
+      eprint={2209.10114},
+      archivePrefix={arXiv},
+      primaryClass={physics.ed-ph},
+      url={https://arxiv.org/abs/2209.10114}, 
+}
+
+@misc{Snowmass:2021_community_engagement_frontier,
+      title={Community Engagement Frontier}, 
+      author={Ketevi A. Assamagan and Breese Quinn and Kenneth Bloom and Veronique Boisvert and Carla Bonifazi and Johan S. Bonilla and Mu-Chun Chen and Sarah M. Demers and Farah Fahim and Rob Fine and Mike Headley and Julie Hogan and Kathryn Jepsen and Sijbrand de Jong and Aneliya Karadzhinova-Ferrer and Yi-Hsuan Lin and Don Lincoln and Sudhir Malik and Alex Murokh and Azwinndini Muronga and Randal Ruchti and Louise Suter and Koji Yoshimura},
+      year={2022},
+      eprint={2211.13210},
+      archivePrefix={arXiv},
+      primaryClass={physics.soc-ph},
+      url={https://arxiv.org/abs/2211.13210}, 
+}
+
 @techreport{Software:2815292,
   author       = {CMS Offline Software and Computing},
   title        = {{CMS Phase-2 Computing Model: Update Document}},
@@ -623,6 +1259,21 @@
   address      = {Geneva},
   year         = {2022},
   url          = {https://cds.cern.ch/record/2815292}
+}
+
+@online{TheCarpentries,
+  title = {The Carpentries},
+  url = {https://carpentries.org}
+}
+
+@misc{traccc,
+      title={Portability: A Necessary Approach for Future Scientific Software}, 
+      author={Meghna Bhattacharya and Paolo Calafiura and Taylor Childers and Mark Dewing and Zhihua Dong and Oliver Gutsche and Salman Habib and Xiangyang Ju and Michael Kirby and Kyle Knoepfel and Matti Kortelainen and Martin Kwok and Charles Leggett and Meifeng Lin and Vincent R. Pascuzzi and Alexei Strelchenko and Brett Viren and Beomki Yeo and Haiwang Yu},
+      year={2022},
+      eprint={2203.09945},
+      archivePrefix={arXiv},
+      primaryClass={physics.comp-ph},
+      url={https://arxiv.org/abs/2203.09945}, 
 }
 
 @misc{tong2024improvinggeneralizingflowbasedgenerative,
@@ -637,6 +1288,7 @@
   primaryclass  = {cs.LG},
   url           = {https://arxiv.org/abs/2302.00482}
 }
+
 @techreport{trackoverlay,
   author        = {Tsai, Fang-Ying},
   collaboration = {ATLAS},
@@ -647,6 +1299,42 @@
   address       = {Geneva},
   year          = {2024},
   url           = {https://cds.cern.ch/record/2907576}
+}
+
+@article{Valassi:2022dkc,
+    author = "Valassi, Andrea and Childers, Taylor and Field, Laurence and Hageboeck, Stefan and Hopkins, Walter and Mattelaer, Olivier and Nichols, Nathan and Roiser, Stefan and Smith, David",
+    title = "{Developments in Performance and Portability for MadGraph5\_aMC@NLO}",
+    eprint = "2210.11122",
+    archivePrefix = "arXiv",
+    primaryClass = "physics.comp-ph",
+    doi = "10.22323/1.414.0212",
+    journal = "PoS",
+    volume = "ICHEP2022",
+    pages = "212",
+    year = "2022"
+}
+
+@article{Wettersten:2023ekm,
+    author = {Wettersten, Zenny and Mattelaer, Olivier and Roiser, Stefan and Sch\"ofbeck, Robert and Valassi, Andrea},
+    title = "{Acceleration beyond lowest order event generation. An outlook on further parallelism within MadGraph5\_aMC@NLO}",
+    eprint = "2312.07440",
+    archivePrefix = "arXiv",
+    primaryClass = "physics.comp-ph",
+    doi = "10.1051/epjconf/202429510001",
+    journal = "EPJ Web Conf.",
+    volume = "295",
+    pages = "10001",
+    year = "2024"
+}
+
+@misc{WLCG:ana_fac_wp,
+      title={Analysis Facilities White Paper}, 
+      author={D. Ciangottini and A. Forti and L. Heinrich and N. Skidmore and C. Alpigiani and M. Aly and D. Benjamin and B. Bockelman and L. Bryant and J. Catmore and M. D'Alfonso and A. Delgado Peris and C. Doglioni and G. Duckeck and P. Elmer and J. Eschle and M. Feickert and J. Frost and R. Gardner and V. Garonne and M. Giffels and J. Gooding and E. Gramstad and L. Gray and B. Hegner and A. Held and J. Hernández and B. Holzman and F. Hu and B. K. Jashal and D. Kondratyev and E. Kourlitis and L. Kreczko and I. Krommydas and T. Kuhr and E. Lancon and C. Lange and D. Lange and J. Lange and P. Lenzi and T. Linden and V. Martinez Outschoorn and S. McKee and J. F. Molina and M. Neubauer and A. Novak and I. Osborne and F. Ould-Saada and A. P. Pages and K. Pedro and A. Perez-Calero Yzquierdo and S. Piperov and J. Pivarski and E. Rodrigues and N. Sahoo and A. Sciaba and M. Schulz and L. Sexton-Kennedy and O. Shadura and T. Šimko and N. Smith and D. Spiga and G. Stark and G. Stewart and I. Vukotic and G. Watts},
+      year={2024},
+      eprint={2404.02100},
+      archivePrefix={arXiv},
+      primaryClass={hep-ex},
+      url={https://arxiv.org/abs/2404.02100}, 
 }
 
 @online{wlcgsust,

--- a/hep-eppsu-software.tex
+++ b/hep-eppsu-software.tex
@@ -120,7 +120,8 @@ methods are currently being tested by ATLAS and CMS.
 Matrix element calculations, which are usually the most CPU intensive part of
 higher order MCEG computations, can be offloaded to GPUs. The first benchmarking
 of the gains from using the GPU version of
-Madgraph~\cite{Alwall:2014hca,MadgraphOnGPU} for leading-order calculations was
+Madgraph~\cite{Alwall:2014hca, Hageboeck:2023blb, Valassi:2022dkc, Wettersten:2023ekm}
+for leading-order calculations was
 performed by the CMS Collaboration~\cite{CMS-DP-2024-086}) and showed
 improvement up to $\times 7$ in event generation time. The PEPPER (Portable
 Engine for the Production of Parton-level Event Records)~\cite{Bothmann:2023gew}
@@ -222,15 +223,15 @@ generators.
 Although neutrino event generators are at an earlier stage of development and
 supported by a smaller workforce, there are many challenges shared with
 simulation efforts in collider experiments and other branches of
-HEP~\cite{2203.11110}. Specific obstacles to the neutrino community must also be
+HEP~\cite{campbell2024eg}. Specific obstacles to the neutrino community must also be
 overcome. The field is heavily reliant upon nuclear research, which is often
 funded for other applications. Technical barriers already solved for the LHC
 still remain an issue for the neutrino community due to a lack of dedicated
 effort. E.g., there is no common event format (although one has 
-been proposed~\cite{2310.13211}) and no standardised interfaces for related
+been proposed~\cite{gardiner2024nuhepmc}) and no standardised interfaces for related
 software. Implementation of new models also typically remains very labour
 intensive, with adaptation of LHC techniques for streamlining the work only just
-beginning~\cite{https://doi.org/10.1103/PhysRevD.105.096006}. Supporting the
+beginning~\cite{PhysRevD.105.096006}. Supporting the
 wide variety of new physics searches envisioned for future experiments, will, in
 particular, require novel approaches.
 
@@ -271,7 +272,8 @@ channels, is a major component of experiment computing budgets.
 \subsection{Baseline Simulation Code
 Needs}\label{baseline-simulation-code-needs}
 
-Almost every HEP experiment uses the Geant4\cite{geant4} simulation toolkit. Its
+Almost every HEP experiment uses the Geant4\cite{ALLISON2016187, 1610988, GEANT4:2002zbu}
+simulation toolkit. Its
 development and maintenance over the long timescales, driven by the needs of
 experiments using the toolkit, are of critical importance and need to be
 supported. Higher intensity and luminosity require more precision, as does the
@@ -290,7 +292,7 @@ digitisation step is heavily dependent on detector design and consumes
 significant computing for all LHC experiments. Re-use of background
 induced digitised output has been deployed by all of them.
 
-Since the last EPPSU {[}strategy{]}, most LHC experiments have transitioned
+Since the last EPPSU\cite{European:2720131}, most LHC experiments have transitioned
 their simulation applications to multi-threaded execution, supported by Geant4,
 and modernised their code. ALICE uses sub-event parallelism, which is now being
 implemented in Geant4. ATLAS and CMS have reported {[}atlas,cms{]} throughput
@@ -322,10 +324,10 @@ Intensity Frontier and Dark Matter experiments~\cite{opticksCHEP}.
 
 \subsection{Fast Simulation}\label{fast-simulation}
 
-Since the last Strategy Update {[}strategy{]}, a variety of fast simulation
+Since the last Strategy Update\cite{European:2720131}, a variety of fast simulation
 techniques have been developed and used in the experiments' Monte Carlo
 production. Parametrised and generative machine learning (ML) approaches for
-calorimeter shower simulations are used (e.g., {[}af3{]}), or planned to be
+calorimeter shower simulations are used (e.g. \cite{af3}), or planned to be
 used, in a substantial fraction of Monte Carlo production by ATLAS, CMS, and
 LHCb. The use of fast simulation is expected to increase in the next few years,
 with more applications transitioning from R\&D to production. More sophisticated
@@ -366,7 +368,7 @@ usually required and it is important to be able to simulate many
 different design variations, so flexibility and ease of use are
 essential. Studies for detectors at proposed future colliders are using
 the common Key4hep~\cite{Ganis2022} framework. Gaseous detector R\&D relies
-heavily on Garfield++ {[}garfield++{]} for detailed modelling of signal
+heavily on Garfield++\cite{garfield++} for detailed modelling of signal
 formation. Long term support of these tools is critical.
 
 The FCC-ee experiments should collect data sets similar or
@@ -403,17 +405,19 @@ hadronic interaction simulation to higher energy, as well as overlay of up to
 \section{Reconstruction and Software
 Triggers}\label{reconstruction-and-software-triggers}
 
-LHCb {[}2{]} and CMS {[}3{]} are now successfully operating GPU farms for their
-Run 3 software trigger systems and ALICE {[}4{]} uses such a farm for
+LHCb\cite{LHCb:RTDP} and CMS\cite{CMS:Detector_R3}
+are now successfully operating GPU farms for their
+Run 3 software trigger systems and ALICE\cite{ALICE:LS2_upgrades} uses such a farm for
 calibration of the detectors and the compression of the real data. This
 effort has produced impressive, sustainable production software providing
 speed-ups, portability and vendor
-independence~\cite{ALICE:vendorunlockedITS,LHb:Allen,MathesP3MA2017}. The
+independence~\cite{Concas:2024cyu, Aaij2020Allen,MathesP3MA2017}. The
 upgrade has enabled ALICE and LHCb to fully adopt real-time analysis strategies,
 discarding raw data in favour of highly compressed or reconstructed
 data. This reduces storage needs and meets baseline physics goals, demonstrating that
-online calibration and detector alignment in quasi real-time is possible. ATLAS
-{[}5{]} and CMS {[}6{]} have increased their bandwidth allocation for real-time
+online calibration and detector alignment in quasi real-time is possible.
+ATLAS\cite{ATLAS:trigger_LS3} and CMS\cite{CMS:enriching_phys_programs}
+have increased their bandwidth allocation for real-time
 analysis triggers in Run 3 by factors of 2 to 3, allowing them to
 collect up to an order of magnitude more physics events beyond
 baseline for low mass exotic particle resonance searches.
@@ -423,9 +427,10 @@ widely addressed by ML and AI algorithms. AI tools are already used extensively
 in HEP offline software and are increasingly found in online software as well as
 hardware DAQ systems. For example, ATLAS uses, and continuously improves, graph
 neural networks based heavy flavour jet and tau identification in its high-level
-trigger (HLT) {[}7{]} in Run 3. CMS deployed a variational autoencoder based on
-an anomaly detection demonstrator in their Level-1 trigger in 2023 {[}8{]},
-making use of HLS4ML {[}9{]}, a HEP community-driven
+trigger (HLT)\cite{ATLAS:perf_commissioning} in Run 3.
+CMS deployed a variational autoencoder based on
+an anomaly detection demonstrator in their Level-1 trigger in 2023\cite{CMS-DP-2023-079},
+making use of HLS4ML\cite{fastml_team_hls4ml}, a HEP community-driven
 software package for high level synthesis of ML algorithms for FPGAs. In Run 3,
 LHCb has deployed monotonic Lipschitz networks at the HLT
 stage~\cite{LHCb:Lipschitz} to select heavy-flavour-quark decays in an efficient
@@ -445,7 +450,7 @@ first level trigger. The next important advancement will be 4D reconstruction,
 track reconstruction with the use of hit time information. This will be
 applicable at the HL-LHC and to future hadron, electron-positron, and deep
 inelastic scattering collider facilities for background mitigation. The tracking
-R\&D area has fostered the A Common Tracking Software (ACTS) project {[}10{]},
+R\&D area has fostered the A Common Tracking Software (ACTS) project\cite{Ai2022Common},
 an excellent example of a common software toolkit used by several experiments to
 tackle tracking challenges as a community. It is already proving a useful
 platform for common tools, such as traccc~\cite{traccc}, a demonstrator project
@@ -577,11 +582,11 @@ appealing language.
 
 In parallel, data analysis frameworks are improving integration with computing
 infrastructure. The ROOT framework has developed the
-RDataFrame~\cite{10.1051/epjconf/201921406029} interface, with improved
-multithreading and interfaces to Spark~\cite{https://doi.org/10.1145/2934664}
-and Dask~\cite{doi:10.25080/Majora-7b98e3ed-013}, two popular distributed
+RDataFrame~\cite{ROOT:RDataFrame} interface, with improved
+multithreading and interfaces to Spark~\cite{10.1145/2934664}
+and Dask~\cite{matthew_rocklin-proc-scipy-2015}, two popular distributed
 computing technologies. In the Scikit-HEP ecosystem,
-awkward-array~\cite{2001.06307} and Coffea~\cite{2008.12712} have closely
+awkward-array~\cite{Pivarski_2020} and Coffea~\cite{Smith_2020} have closely
 integrated Dask to achieve scalability.
 
 Given the wide range of tools available to HEP analysts, interoperability across
@@ -589,7 +594,7 @@ the software ecosystem is necessary, with the need to build well-specified and
 interoperable data structures for all stages of analysis. The ROOT RNTuple data
 serialisation interface, replacing the TTree interface, has a clear
 specification as well as significant enhancements in support for multithreading
-and asynchronous I/O~\cite{https://doi.org/10.1051/epjconf/202429506020}. The
+and asynchronous I/O~\cite{ROOT:RDataFrame_prod_path}. The
 HEP Statistics serialisation Standard (HS3) aims to provide a common, framework
 agnostic serialised description of the components involved in fitting
 statistical models (models, datasets, likelihoods,
@@ -602,7 +607,7 @@ ML has had a transformative impact on HEP and become a core part of HEP data
 analysis. Traditionally, ML algorithms such as decision trees and neural
 networks (NNs), are used to efficiently classify events. More recently, the use
 of ML in analysis has extended to statistical inference, with results from
-ATLAS~\cite{https://arxiv.org/pdf/2412.01548,https://arxiv.org/pdf/2412.01600}
+ATLAS~\cite{ATLAS:2024_hzz_higgs, ATLAS:neural_sim_inference}
 using simulation-based inference, wherein ML classifiers are trained on
 simulation and used to construct statistics, such as likelihood ratios, which
 can be evaluated on data. We expect ML to keep playing a significant role in the
@@ -651,9 +656,9 @@ With the ever-increasing scale of data to be processed in HEP analyses, it is
 vital that analysts can employ large scale distributed computing resources.
 Analysis facilities (AFs) provide an approach to analysis infrastructure in
 which analysts can interface with these resources whilst also being able to
-prototype and execute their analyses interactively~\cite{AF WP}. Demonstrators
+prototype and execute their analyses interactively~\cite{WLCG:ana_fac_wp}. Demonstrators
 such as the Analysis Grand Challenge
-initiative~\cite{https://doi.org/10.22323/1.414.0235}, in which physics analyses
+initiative~\cite{Held:2022RC}, in which physics analyses
 are performed to test the technologies which will be required for the HL-LHC,
 and many prototype AFs~\cite{AF pilot ref?} have shown promise in this model.
 
@@ -684,19 +689,21 @@ tools and software frameworks taught are experiment-specific, a considerable
 amount of training is invested in common software tools and skills like Python,
 C++, ML, CI/CD, and analysis preservation and reproducibility, etc. There is a
 growing consensus in the HEP community on the need for common training programs
-to bring researchers up to date with new software technologies~\cite{4-7}. As a
-result, in the past 5 years the HSF~\cite{8}, together with Institute for
-Research and Innovation in Software for High Energy Physics (IRIS-HEP)~\cite{9},
-CERN EP-SFT group and FIRST-HEP~\cite{10}, and partnering with The
-Carpentries~\cite{11}, and PyHEP~\cite{13} have developed material for an
-introductory, intermediate and advanced HEP software curriculum~\cite{14} taught
+to bring researchers up to date with new software
+technologies~\cite{HSF-CWP-2017-02,Snowmass:2021_community_engagement_frontier, Snowmass:2021_career_pipeline}.
+As a result, in the past 5 years the HSF~\cite{HSFTraining}, together with Institute for
+Research and Innovation in Software for High Energy Physics (IRIS-HEP)~\cite{IRISHEP:Training},
+CERN EP-SFT group and FIRST-HEP~\cite{FIRST-HEP}, and partnering with The
+Carpentries~\cite{TheCarpentries}, and PyHEP~\cite{HSFPyHEP} have developed material for an
+introductory, intermediate and advanced HEP software curriculum~\cite{HSFTrainingCenter} taught
 to HEP users. In addition, several of our major conferences have tracks on
 software training and corresponding efforts. Other specific training efforts
-include CoDAS-HEP~\cite{15}, Bertinoro~\cite{16}, CERN School of
-Computing~\cite{17} and CERN OpenLab Software workshops~\cite{18}. Thus far,
+include CoDAS-HEP~\cite{CODAS-HEP}, Bertinoro~\cite{INFN:ESC_school}, CERN School of
+Computing~\cite{CERN:computing_school} and CERN OpenLab Software
+workshops~\cite{CERN:SW_workshops}. Thus far,
 over 3000 users in HEP, related Nuclear Physics and computing areas have been
 trained. Current training work has also been published in journals and
-conference proceedings~\cite{19-21}.
+conference proceedings~\cite{Malik:2919564, Malik:chep2023_training_outreach, Malik2021Software}.
 
 \subsection{Challenges and
 Opportunities}\label{challenges-and-opportunities}
@@ -733,7 +740,7 @@ favours visibility and recognition of those working on data analysis projects or
 detector hardware rather than those invested in software and computing. This
 must change if we want to meet future challenges over decades and in multiple
 experiments, which increasingly requires large and long lived software projects.
-We must~\cite{22} provide such opportunities and provide a career path for those
+We must~\cite{hsfcwp} provide such opportunities and provide a career path for those
 involved in software and computing, including in training, by creating job
 opportunities at labs and universities on par with those involved in detector
 construction. This must be supported by increased visibility like publications,


### PR DESCRIPTION
Status after this PR and main issues identified:

- Section 1 ok
- Section 2 (MPEGs) done
- Section 3  (Simulation)
  - [x] AdePT reference asked to Andrei Gheata
  - [x] traccc reference to be validated
  - 3 unresolved references:
    - [x] atlas
    - [x] cms
    - [x] "add CHEP refs for A and C" (moved to issue #9)
- Section 4 (Reconstruction & SW triggers) done
- Section 5 (Data analysis)
  - [x] 5.2: Chen˙2022, Duarte:2022job, Fair4AIWorkshop, cwl, snakemake, luigilaw, yadage, REANA undefined
  - [x] fairguiding undefined
  - [x] 5.3: AF Pilot reference undefined
- Section 6 (Training & Careers)
  - [x] 6.1 : [6] (https://www.slac.stanford.edu/econf/C210711/reports/Engagement.pdf) = [5] (https://www.slac.stanford.edu/econf/C210711/Engagement.html) ?
