### PR TITLE
Minor reference fix

### DIFF
--- a/hep-eppsu-software.bib
+++ b/hep-eppsu-software.bib
@@ -785,7 +785,7 @@
 }
 
 @misc{g4inputs,
-  title = {Geant4 Input to Community Input on the EPPSU},
+  title = {Geant4 Input to the EPPSU},
   year  = 2024,
   url   = {https://indico.cern.ch/event/1475445/}
 }


### PR DESCRIPTION
Shorten the description "title" for the Geant4 inputs, which is more concise and helps with the citation formatting.

Contributes to #9 I believe!